### PR TITLE
Add ROOT/kubevirt folder

### DIFF
--- a/kubevirt/README.md
+++ b/kubevirt/README.md
@@ -1,0 +1,43 @@
+This folder contains kubevirt-related
+ - development documentation and notes
+ - build and deployment scripts and configuration
+
+# Other kubevirt content
+```
+./frontend/public/kubevirt
+./frontend/__tests__/kubevirt
+./frontend/public/imgs/logos/kubevirt.svg
+```
+
+# Upstream merges
+The [kubevirt/web-ui](https://github.com/kubevirt/web-ui) project is fork of [openshift/console](https://github.com/openshift/console/).
+
+Upstream changes are merged regularly using `${ROOT}/kubevirt/mergeUpstream` script to keep both projects in sync.
+
+# Build
+TBD - how to build docker image
+
+# Development Environment
+Is same as for openshift/console. See project's [README.md](https://github.com/kubevirt/web-ui/blob/master/README.md).\
+
+# Deployment
+TBD - use of kubevirt-web-ui.yaml and other configuration
+
+
+# List of important patches
+Kubevirt-related code lives either in separate `**/kubevirt` folders (see above) or in external projects referenced from web-ui (like [web-ui-components](https://github.com/kubevirt/web-ui-components) or [patternfly-react](https://github.com/patternfly/patternfly-react/)).
+
+Changes to OKD code are kept at bare minimum to allow both smooth merges or recomposing the UI within another application in the future.
+
+## Full list of changes compared to upstream:
+```
+git remote add openshift_console https://github.com/openshift/console.git
+git remote add kubevirt_web_ui https://github.com/kubevirt/web-ui.git
+git fetch --all
+git log remotes/openshift_console/master..remotes/kubevirt_web_ui/master
+```
+
+## List of important OKD-core changes: 
+ - https://github.com/kubevirt/web-ui/pull/1
+
+ 

--- a/kubevirt/kubevirt-web-ui.yaml
+++ b/kubevirt/kubevirt-web-ui.yaml
@@ -1,0 +1,66 @@
+apiVersion: v1
+kind: ReplicationController
+metadata:
+  labels:
+    app: kubevirt-web-ui
+    openshift.io/deployment-config.name: kubevirt-web-ui
+  name: kubevirt-web-ui
+  namespace: kubevirt-web-ui
+spec:
+  replicas: 1
+  selector:
+    app: kubevirt-web-ui
+    deployment: kubevirt-web-ui
+    deploymentconfig: kubevirt-web-ui
+  template:
+    metadata:
+      labels:
+        app: kubevirt-web-ui
+        deployment: kubevirt-web-ui
+        deploymentconfig: kubevirt-web-ui
+    spec:
+      containers:
+        - image: docker.io/mareklibra/kubevirt-web-ui:f679e704219f58aea97a1433ea01e7c7227afc7d
+          imagePullPolicy: IfNotPresent
+          name: kubevirt-web-ui
+          resources: {}
+      dnsPolicy: ClusterFirst
+      restartPolicy: Always
+      schedulerName: default-scheduler
+      securityContext: {}
+      terminationGracePeriodSeconds: 30
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: kubevirt-web-ui
+  name: kubevirt-web-ui
+  namespace: kubevirt-web-ui
+spec:
+  ports:
+    - name: https
+      port: 9000
+      protocol: TCP
+      targetPort: 9000
+  selector:
+    deploymentconfig: kubevirt-web-ui
+  sessionAffinity: None
+  type: ClusterIP
+---
+apiVersion: route.openshift.io/v1
+kind: Route
+metadata:
+  labels:
+    app: kubevirt-web-ui
+  name: kubevirt-web-ui
+  namespace: kubevirt-web-ui
+spec:
+  port:
+    targetPort: https
+  to:
+    kind: Service
+    name: kubevirt-web-ui
+    weight: 100
+  wildcardPolicy: None
+

--- a/kubevirt/mergeUpstream.sh
+++ b/kubevirt/mergeUpstream.sh
@@ -1,0 +1,44 @@
+#!/bin/bash
+set -x
+
+UNIQUE=`date +%D_%T|sed 's/\//_/g'|sed 's/:/-/g'`
+ROOT=~/tmp/console-mergeUpstream-${UNIQUE}
+MERGE_BRANCH=mergeUpstream_${UNIQUE}
+
+UPSTREAM_GIT=https://github.com/openshift/console.git # the source of patches to be merged
+UPSTREAM_BRANCH=master
+
+PRIVATE_GIT_USER=mareklibra # acts as a mediator to not create dummy branches under OKDVIRT_REPO
+PRIVATE_REPO=https://github.com/${PRIVATE_GIT_USER}/kubevirt-web-ui # note: create your own fork of UPSTREAM_GIT here
+PRIVATE_GIT=${PRIVATE_REPO}.git
+
+OKDVIRT_REPO=https://github.com/kubevirt/web-ui # The repo where new PR is about to be created
+OKDVIRT_GIT=${OKDVIRT_REPO}.git
+OKDVIRT_BRANCH=master # the PR target branch
+
+rm -rf ${ROOT}
+git clone ${PRIVATE_GIT} ${ROOT}
+cd ${ROOT}
+git remote add upstream ${UPSTREAM_GIT}
+git remote add okdvirt ${OKDVIRT_GIT}
+git fetch --all
+
+git checkout okdvirt/${OKDVIRT_BRANCH}
+git checkout -b ${MERGE_BRANCH}
+git merge upstream/${UPSTREAM_BRANCH}
+
+cat <<EOF
+Now resolve all merge conflicts in following directory:
+
+  cd ${ROOT} && get status
+
+Then open pull-request by
+
+  git push --set-upstream origin ${MERGE_BRANCH}
+  firefox ${OKDVIRT_REPO}/compare/${OKDVIRT_BRANCH}...${PRIVATE_GIT_USER}:${MERGE_BRANCH}?expand=1 &
+
+To see kubevirt/web-ui diference to upstream
+
+  git log remotes/upstream/master..${MERGE_BRANCH}
+EOF
+


### PR DESCRIPTION
The folder holds documentation, deployment configuration and various
tools supporting kubevirt-related development processes.

Within this patch, following is added
- README
- kubevirt-web-ui.yaml - first version of deployment configuration
- mergeUpstream.sh script - to merge openshift/console changes back to our fork