### PR TITLE
Add travis for unit tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,9 @@
+language: node_js
+node_js:
+  - '10'
+cache: yarn
+before_install: cd frontend
+script:
+- yarn run lint
+- CI=true yarn test --ci --debug --verbose
+


### PR DESCRIPTION
So far integration tests are executed only.
Integration tests would require running OpenShift.

Fixes: https://github.com/kubevirt/web-ui/issues/4