### PR TITLE
Build.use yarn1.9.4

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,5 @@
-FROM quay.io/coreos/tectonic-console-builder:v16 AS build
+#FROM quay.io/coreos/tectonic-console-builder:v16 AS build
+FROM mareklibra/tectonic-console-builder:v1 AS build
 
 RUN mkdir -p /go/src/github.com/openshift/console/
 ADD . /go/src/github.com/openshift/console/

--- a/Dockerfile-builder
+++ b/Dockerfile-builder
@@ -12,7 +12,7 @@ RUN go get github.com/jstemmer/go-junit-report
 
 ### Install NodeJS and yarn
 ENV NODE_VERSION="v10.3.0"
-ENV YARN_VERSION="v1.7.0"
+ENV YARN_VERSION="v1.9.4"
 
 # yarn needs a home writable by any user running the container
 ENV HOME /opt/home

--- a/push-builder.sh
+++ b/push-builder.sh
@@ -11,7 +11,8 @@ if [ -z "${DOCKER_TAG}" ]; then
     exit 1
 fi
 
-DOCKER_IMAGE=quay.io/coreos/tectonic-console-builder:${DOCKER_TAG}
+#DOCKER_IMAGE=quay.io/coreos/tectonic-console-builder:${DOCKER_TAG}
+DOCKER_IMAGE=mareklibra/tectonic-console-builder:${DOCKER_TAG}
 
 docker build --rm=true -t "${DOCKER_IMAGE}" - < Dockerfile-builder
 docker push "${DOCKER_IMAGE}"


### PR DESCRIPTION
The `kubevirt-web-ui-components` recently requires `yarn >= 1.9.0`.
But current `openshift/console` build image is based on `yarn 1.7.0`.

Unless we decrease this dependency in `kubevirt-web-ui-components`, we have to deviate from `openshift/console` by using custom builder image.
