### PR TITLE
travis: add docker build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,4 +11,4 @@ script:
 - yarn run lint
 - CI=true yarn test --maxWorkers=2
 - MAX_WORKERS=1 yarn run build
-
+- cd .. && docker build -q --rm=true -f Dockerfile -t kubevirt-web-ui-travis:test-build-only .


### PR DESCRIPTION
Recently there is no use for the resulting docker image.
The goal is just to pass the build for verification.