### PR TITLE
mergeUpstream.sh: Merge to HEAD:master directly

### DIFF
--- a/kubevirt/mergeUpstream.sh
+++ b/kubevirt/mergeUpstream.sh
@@ -8,23 +8,17 @@ MERGE_BRANCH=mergeUpstream_${UNIQUE}
 UPSTREAM_GIT=https://github.com/openshift/console.git # the source of patches to be merged
 UPSTREAM_BRANCH=master
 
-PRIVATE_GIT_USER=mareklibra # acts as a mediator to not create dummy branches under OKDVIRT_REPO
-PRIVATE_REPO=https://github.com/${PRIVATE_GIT_USER}/kubevirt-web-ui # note: create your own fork of UPSTREAM_GIT here
-PRIVATE_GIT=${PRIVATE_REPO}.git
-
 OKDVIRT_REPO=https://github.com/kubevirt/web-ui # The repo where new PR is about to be created
 OKDVIRT_GIT=${OKDVIRT_REPO}.git
 OKDVIRT_BRANCH=master # the PR target branch
 
 rm -rf ${ROOT}
-git clone ${PRIVATE_GIT} ${ROOT}
+git clone ${OKDVIRT_GIT} ${ROOT}
 cd ${ROOT}
 git remote add upstream ${UPSTREAM_GIT}
-git remote add okdvirt ${OKDVIRT_GIT}
 git fetch --all
 
-git checkout okdvirt/${OKDVIRT_BRANCH}
-git checkout -b ${MERGE_BRANCH}
+git checkout -b okdvirt.master -t remotes/origin/${OKDVIRT_BRANCH}
 git merge upstream/${UPSTREAM_BRANCH}
 
 cat <<EOF
@@ -32,13 +26,13 @@ Now resolve all merge conflicts in following directory:
 
   cd ${ROOT} && git status
 
-Then open pull-request by
+Then push changes to kubevirt-web-ui HEAD:master by
 
-  git push --set-upstream origin ${MERGE_BRANCH}
-  firefox ${OKDVIRT_REPO}/compare/${OKDVIRT_BRANCH}...${PRIVATE_GIT_USER}:${MERGE_BRANCH}?expand=1 &
+  cd ${ROOT} && ./build.sh && cd frontent && yarn run test && \\
+  git status && git push origin HEAD:master
 
 To see kubevirt/web-ui diference to upstream
 
-  git log remotes/upstream/master..${MERGE_BRANCH}
+  git log remotes/upstream/master..${OKDVIRT_BRANCH}
 EOF
 


### PR DESCRIPTION
Intermediate step with Pull Request is skipped and openshift/console
master commits are pushed to kubevirt/web-ui master branch immediately.

With this patch, the openshift/console difference is stacked onto
kubevirt/web-ui HEAD:master lineary, sort of github's
"rebase & merge" action but without conflicts.