### PR TITLE
consoles: add spinner when VM is starting

### DIFF
--- a/frontend/public/kubevirt/components/_vmconsoles.scss
+++ b/frontend/public/kubevirt/components/_vmconsoles.scss
@@ -1,2 +1,14 @@
 @import '~@patternfly/react-console/dist/css/console.css';
 
+.vm-consoles-loading {
+  text-align: center;
+
+  .co-m-loader--inline {
+    margin-right: 1em;
+  }
+
+  button {
+    vertical-align: baseline;
+    padding: 0;
+  }
+}

--- a/frontend/public/kubevirt/components/modals/start-stop-vm-modal.jsx
+++ b/frontend/public/kubevirt/components/modals/start-stop-vm-modal.jsx
@@ -65,7 +65,7 @@ class StartStopVmModal extends PromiseComponent {
 
 StartStopVmModal.propTypes = {
   start: PropTypes.bool.isRequired,
-  kind: PropTypes.string.isRequired,
+  kind: PropTypes.object.isRequired, /* object of model */
   resource: PropTypes.object.isRequired,
   close: PropTypes.func.isRequired
 };

--- a/frontend/public/kubevirt/components/okdcomponents.jsx
+++ b/frontend/public/kubevirt/components/okdcomponents.jsx
@@ -9,3 +9,4 @@ export * from '../../components/namespace';
 export * from '../../components/global-notifications';
 export * from '../../components/resource-list';
 export * from '../../components/events';
+export * from '../../components/utils/status-box';

--- a/frontend/public/kubevirt/components/utils/resources.js
+++ b/frontend/public/kubevirt/components/utils/resources.js
@@ -33,6 +33,7 @@ export const getFlattenForKind = (kind) => {
 };
 
 export const isVmiRunning = (vmi) => _.get(vmi, 'status.phase') === 'Running';
+export const isVmStarting = (vm, vmi) => _.get(vm, 'spec.running') && !isVmiRunning(vmi);
 
 export const getVmStatus = vm => _.get(vm, 'spec.running', false) ? 'Running' : 'Stopped';
 


### PR DESCRIPTION
The spinner is implemented as "loading dots" to be alligned with
the rest of the application.

Fixes: https://github.com/kubevirt/web-ui/issues/45