### PR TITLE
Upgrade @patternfly/react-console to the latest

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -69,7 +69,7 @@
     "murmurhash-js": "1.0.x",
     "openshift-logos-icon": "1.7.1",
     "patternfly": "^3.54.8",
-    "patternfly-react": "^2.22.0",
+    "patternfly-react": "2.24.3",
     "patternfly-react-extensions": "2.12.8",
     "plotly.js": "1.28.x",
     "prop-types": "15.6.x",

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -8163,15 +8163,16 @@ patternfly-react-extensions@2.12.8:
     patternfly-react "^2.23.0"
     react-virtualized "9.x"
 
-patternfly-react@^2.22.0:
-  version "2.22.0"
-  resolved "https://registry.yarnpkg.com/patternfly-react/-/patternfly-react-2.22.0.tgz#78527be85520089b76f57f0eb7676bb8e1d5afcd"
+patternfly-react@2.24.3:
+  version "2.24.3"
+  resolved "https://registry.yarnpkg.com/patternfly-react/-/patternfly-react-2.24.3.tgz#ed287fb6bf691add70c8b82ef76ee395065382ea"
+  integrity sha512-RyMkN79vWFq5aZLKNEOwKRtZCrElCduD9redU/+c1aAwfoyQbni1zGr1pURZ4FFlZvtB5ul/qRThZtspwc7XfA==
   dependencies:
     bootstrap-slider-without-jquery "^10.0.0"
     breakjs "^1.0.0"
     classnames "^2.2.5"
     css-element-queries "^1.0.1"
-    patternfly "^3.52.4"
+    patternfly "^3.58.0"
     react-bootstrap "^0.32.1"
     react-bootstrap-switch "^15.5.3"
     react-bootstrap-typeahead "^3.1.3"
@@ -8212,6 +8213,38 @@ patternfly-react@^2.23.0:
 patternfly@^3.52.1, patternfly@^3.52.4, patternfly@^3.54.8:
   version "3.54.8"
   resolved "https://registry.yarnpkg.com/patternfly/-/patternfly-3.54.8.tgz#fd6c69714dc460575d2534c9f29017a58b442a83"
+  dependencies:
+    bootstrap "~3.3.7"
+    font-awesome "^4.7.0"
+    jquery "~3.2.1"
+  optionalDependencies:
+    "@types/c3" "^0.6.0"
+    bootstrap-datepicker "^1.7.1"
+    bootstrap-sass "^3.3.7"
+    bootstrap-select "1.12.2"
+    bootstrap-slider "^9.9.0"
+    bootstrap-switch "~3.3.4"
+    bootstrap-touchspin "~3.1.1"
+    c3 "~0.4.11"
+    d3 "~3.5.17"
+    datatables.net "^1.10.15"
+    datatables.net-colreorder "^1.4.1"
+    datatables.net-colreorder-bs "~1.3.2"
+    datatables.net-select "~1.2.0"
+    drmonty-datatables-colvis "~1.1.2"
+    eonasdan-bootstrap-datetimepicker "^4.17.47"
+    font-awesome-sass "^4.7.0"
+    google-code-prettify "~1.0.5"
+    jquery-match-height "^0.7.2"
+    moment "^2.19.1"
+    moment-timezone "^0.4.1"
+    patternfly-bootstrap-combobox "~1.1.7"
+    patternfly-bootstrap-treeview "~2.1.0"
+
+patternfly@^3.58.0:
+  version "3.58.0"
+  resolved "https://registry.yarnpkg.com/patternfly/-/patternfly-3.58.0.tgz#c94516a9fbf2b645b63a53e58fcf39c45bf66a8b"
+  integrity sha512-geY0cbSFXoi9qv9cXCZe0OPCZBuLCuPKfEPXk0usTHjYSk5oUv3KMMuAJidbsbtXqc6vnDYjGfngepIlJ99rfg==
   dependencies:
     bootstrap "~3.3.7"
     font-awesome "^4.7.0"

--- a/kubevirt/package.json
+++ b/kubevirt/package.json
@@ -1,6 +1,6 @@
 {
   "dependencies": {
-    "@patternfly/react-console": "1.5.0",
+    "@patternfly/react-console": "1.7.4",
     "kubevirt-web-ui-components": "^0.1.6",
     "reactabular-dnd": "^8.16.0"
   }

--- a/kubevirt/yarn.lock
+++ b/kubevirt/yarn.lock
@@ -6,17 +6,30 @@
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/@novnc/novnc/-/novnc-1.0.0.tgz#76b0e89e6f8738ca8154195baf5b8e6a80bc9105"
 
-"@patternfly/react-console@1.5.0":
-  version "1.5.0"
-  resolved "https://registry.yarnpkg.com/@patternfly/react-console/-/react-console-1.5.0.tgz#7a3bddb9813033e75c0a7c3fdbea73115e22476d"
+"@patternfly/react-console@1.7.4":
+  version "1.7.4"
+  resolved "https://registry.yarnpkg.com/@patternfly/react-console/-/react-console-1.7.4.tgz#f8c3971d02771c961fb59695ca2f1d59716ab550"
+  integrity sha512-tPl75WxKlBxTh7GpakC8xxIPZ7U1u/l+zb21sT62xTFmR1BCJskit2y/tkRO2FtBselFHoirqXeyiWUs9Ha4ew==
   dependencies:
     "@novnc/novnc" "^1.0.0"
+    blob-polyfill "^3.0.20180112"
     classnames "^2.2.5"
+    file-saver "^1.3.8"
     xterm "^3.3.0"
+
+blob-polyfill@^3.0.20180112:
+  version "3.0.20180112"
+  resolved "https://registry.yarnpkg.com/blob-polyfill/-/blob-polyfill-3.0.20180112.tgz#7f7c3e235ae298867f8c22b429d33aa9a7cc65b5"
+  integrity sha512-DX/47MXO+hNuEhuZRW9/yykNoCe7E/ywcPKtPVqGPRwLlowN811xi/3yVMQkE2fhTGHfrH8O9BMuhM7IdcRyew==
 
 classnames@^2.2.5:
   version "2.2.6"
   resolved "https://registry.yarnpkg.com/classnames/-/classnames-2.2.6.tgz#43935bffdd291f326dad0a205309b38d00f650ce"
+
+file-saver@^1.3.8:
+  version "1.3.8"
+  resolved "https://registry.yarnpkg.com/file-saver/-/file-saver-1.3.8.tgz#e68a30c7cb044e2fb362b428469feb291c2e09d8"
+  integrity sha512-spKHSBQIxxS81N/O21WmuXA2F6wppUCsutpzenOeZzOCCJ5gEfcbqJP983IrpLXzYmXnMUa6J03SubcNPdKrlg==
 
 kubevirt-web-ui-components@^0.1.6:
   version "0.1.7"


### PR DESCRIPTION
Upgrade npm dependency to get latest changes in pf-react consoles.

Issues of upgrade:

pf-react changed structure of dist modules (https://github.com/patternfly/patternfly-react/commit/1f3411a6e708e833e48921380ae736cf5f79862b).
References need to be fixed in pf-raect first: https://github.com/patternfly/patternfly-react/pull/894

Example:
```
in 1.4.6: import { EmptyState, Button, noop } from 'patternfly-react';
in 1.5.6: import noop from 'patternfly-react/dist/esm/components/noop/noop';
in sources: import { EmptyState, Button, noop } from 'patternfly-react';
```