### PR TITLE
ResourceLauncher and refactor show CreateVMWizard

### DIFF
--- a/frontend/public/kubevirt/_style.scss
+++ b/frontend/public/kubevirt/_style.scss
@@ -5,3 +5,4 @@
 @import 'components/vm';
 @import 'components/vmconsoles';
 @import 'components/disk';
+@import 'components/modals/loader';

--- a/frontend/public/kubevirt/components/modals/_loader.scss
+++ b/frontend/public/kubevirt/components/modals/_loader.scss
@@ -1,0 +1,3 @@
+.no-bgcolor {
+    background-color: transparent;
+}

--- a/frontend/public/kubevirt/components/modals/loader.jsx
+++ b/frontend/public/kubevirt/components/modals/loader.jsx
@@ -1,0 +1,43 @@
+import * as React from 'react';
+import PropTypes from 'prop-types';
+
+const ESC_KEY = 27;
+
+/**
+ * Empty loader
+ * // TODO: add loading icon
+ */
+export class Loader extends React.Component {
+
+  constructor (props) {
+    super(props);
+
+    this.onKeydown = this.onKeydown.bind(this);
+  }
+
+  componentDidMount () {
+    document.addEventListener('keydown', this.onKeydown);
+  }
+
+  componentWillUnmount () {
+    document.removeEventListener('keydown', this.onKeydown);
+  }
+
+  onKeydown (event) {
+    if (event.key === 'Escape' || event.keyCode === ESC_KEY) {
+      this.props.onExit(event);
+    }
+  }
+
+  render () {
+    return (
+      <div role="dialog-loader" onClick={this.props.onExit} >
+        <div className="fade modal-backdrop in no-bgcolor" />
+      </div>
+    );
+  }
+}
+
+Loader.propTypes = {
+  onExit: PropTypes.func.isRequired,
+};

--- a/frontend/public/kubevirt/components/okdcomponents.jsx
+++ b/frontend/public/kubevirt/components/okdcomponents.jsx
@@ -10,3 +10,4 @@ export * from '../../components/global-notifications';
 export * from '../../components/resource-list';
 export * from '../../components/events';
 export * from '../../components/utils/status-box';
+export * from '../../components/modals/error-modal';

--- a/frontend/public/kubevirt/components/utils/resourceLauncher.jsx
+++ b/frontend/public/kubevirt/components/utils/resourceLauncher.jsx
@@ -1,0 +1,50 @@
+import * as React from 'react';
+import * as ReactDOM from 'react-dom';
+import { Provider } from 'react-redux';
+import { Router } from 'react-router-dom';
+
+import { Firehose } from '../utils/okdutils';
+import { history } from '../../../components/utils';
+import store from '../../../redux';
+
+import { WithResources } from './withResources';
+
+const EMPTY_LIST = [];
+const EMPTY_OBJECT = {};
+
+export const resourceLauncher = (Component, resourceMap, resourceToProps) => (props) => {
+  const modalContainer = document.getElementById('modal-container');
+
+  const result = new Promise(resolve => {
+    const closeModal = e => {
+      if (e && e.stopPropagation) {
+        e.stopPropagation();
+      }
+      ReactDOM.unmountComponentAtNode(modalContainer);
+      resolve();
+    };
+
+    const emptyResources = {};
+
+    // to skip react required warnings - because we are injecting (and overwriting) them later in WithResources
+    Object.keys(resourceMap).forEach(k => {
+      if (resourceMap[k].isRequired) {
+        emptyResources[k] = resourceMap[k].resource.isList ? EMPTY_LIST : EMPTY_OBJECT;
+      }
+    });
+
+    ReactDOM.render(<Provider store={store}>
+      <Router {...{
+        history,
+        basename: window.SERVER_FLAGS.basePath
+      }}>
+        <Firehose resources={Object.keys(resourceMap).map(k => resourceMap[k].resource)}>
+          <WithResources resourceMap={resourceMap} dispose={closeModal} resourceToProps={resourceToProps}>
+            <Component {...props} {...emptyResources} onClose={closeModal} onCancel={closeModal} onHide={closeModal} />
+          </WithResources>
+        </Firehose>
+      </Router>
+    </Provider>, modalContainer);
+  });
+  return { result };
+};

--- a/frontend/public/kubevirt/components/utils/showErrors.jsx
+++ b/frontend/public/kubevirt/components/utils/showErrors.jsx
@@ -1,0 +1,42 @@
+import * as React from 'react';
+import PropTypes from 'prop-types';
+
+import { errorModal } from '../okdcomponents';
+import { Alert } from 'patternfly-react';
+
+const safeString = (x) => typeof x === 'string' ? x : JSON.stringify(x);
+
+const Errors = ({ errors }) => {
+  let content;
+  if (errors.length === 1) {
+    content =safeString(errors[0]);
+  } else {
+    content = (
+      <ul>
+        {errors.map((error, idx) => <li key={idx}>{safeString(error)}</li>)}
+      </ul>
+    );
+  }
+
+  return (
+    <Alert>
+      {content}
+    </Alert>
+  );
+};
+
+Errors.propTypes = {
+  errors: PropTypes.array.isRequired,
+};
+
+export const showErrors = (errors) => {
+  if (errors && errors.length > 0) {
+    errorModal({
+      error: (<Errors errors={errors} />)
+    });
+  }
+};
+
+export const showError = (error) => {
+  showErrors([error]);
+};

--- a/frontend/public/kubevirt/components/utils/withResources.jsx
+++ b/frontend/public/kubevirt/components/utils/withResources.jsx
@@ -1,0 +1,86 @@
+import * as React from 'react';
+import PropTypes from 'prop-types';
+import * as _ from 'lodash-es';
+
+import { inject } from '../../../components/utils';
+
+import { Loader } from '../modals/loader';
+import { showErrors } from './showErrors';
+
+
+const checkErrors = (errors, dispose) => {
+  if (errors.length > 0) {
+    dispose();
+    setTimeout(() => {
+      showErrors(errors);
+    }, 0);
+  }
+};
+
+/*
+ * Firehose helper
+ */
+export class WithResources extends React.Component {
+
+  constructor (props) {
+    super(props);
+    this.state = WithResources.getDerivedStateFromProps(props);
+    checkErrors(this.state.errors, props.dispose);
+  }
+
+  static getDerivedStateFromProps ({ resourceMap, resources, resourceToProps }) {
+    const childrenProps = {};
+    const errors = [];
+    let loaded = true;
+
+    Object.keys(resourceMap).forEach(resourceKey => {
+      const resourceConfig = resourceMap[resourceKey];
+      const resource = _.get(resources, resourceConfig.resource.kind);
+
+      if (resource) {
+        if (resource.loaded) {
+          childrenProps[resourceKey] = resource.data;
+        } else if (resourceConfig.required) {
+          loaded = false;
+        }
+
+        if (resource.loadError) {
+          errors.push(resource.loadError);
+        }
+      } else {
+        // unknown resources (CRD not created in opeshift, etc..)
+        childrenProps[resourceKey] = resourceConfig.resource.isList ? [] : {};
+      }
+    });
+
+    return {
+      childrenProps: {
+        ...childrenProps,
+        ...(resourceToProps ? resourceToProps(childrenProps) : {})
+      },
+      errors,
+      loaded,
+    };
+  }
+
+  componentDidUpdate () {
+    checkErrors(this.state.errors, this.props.dispose);
+  }
+
+  render () {
+    const { dispose, children } = this.props;
+
+    if (!this.state.loaded) {
+      return <Loader onExit={dispose} />;
+    }
+
+    return inject(children, this.state.childrenProps);
+  }
+}
+
+WithResources.propTypes = {
+  resources: PropTypes.array.isRequired,
+  resourceMap: PropTypes.object.isRequired,
+  dispose: PropTypes.func.isRequired,
+  resourceToProps: PropTypes.func,
+};


### PR DESCRIPTION
features 
- opening dialog in new ReactDOM (inspired by createModalLauncher) for any type of a dialog

1. specify a component
2. declare resources and their names
3. resourceToProps for derived resources
4. pass component props 

- possibility to mark resource as required: the dialog will open once all the resource have been loaded, otherwise empty resources are passed to the dialog
- Error Dialog will be shown if loading of resources failed.

replaces #110 and will be also used by MigrationDialog