### PR TITLE
[OKD-core] Add VM Template list

### DIFF
--- a/frontend/public/components/app.jsx
+++ b/frontend/public/components/app.jsx
@@ -30,6 +30,7 @@ import '../style.scss';
 
 import { KubevirtDefaultPage } from '../kubevirt/components/app';
 import { isKubevirt } from '../kubevirt/components/utils/selectors';
+import { VirtualMachineTemplatesPage } from '../kubevirt/components/vm-template';
 
 // Edge lacks URLSearchParams
 import 'url-search-params-polyfill';
@@ -178,6 +179,9 @@ class App extends React.PureComponent {
             <Route path="/k8s/ns/:ns/customresourcedefinitions/:plural/:name" component={ResourceDetailsPage} />
             <Route path="/k8s/all-namespaces/customresourcedefinitions/:plural" exact component={ResourceListPage} />
             <Route path="/k8s/all-namespaces/customresourcedefinitions/:plural/:name" component={ResourceDetailsPage} />
+
+            <Route path="/k8s/ns/:ns/vmtemplates" exact component={VirtualMachineTemplatesPage} />
+            <Route path="/k8s/all-namespaces/vmtemplates" exact component={VirtualMachineTemplatesPage} />
 
             {
               // These pages are temporarily disabled. We need to update the safe resources list.

--- a/frontend/public/components/resource-pages.ts
+++ b/frontend/public/components/resource-pages.ts
@@ -54,6 +54,7 @@ import {
   SubscriptionModel,
   VirtualMachineModel,
   PackageManifestModel,
+  VmTemplateModel,
 } from '../models';
 
 export const resourceDetailPages = ImmutableMap<GroupVersionKind | string, () => Promise<React.ComponentType<any>>>()
@@ -148,6 +149,7 @@ export const resourceListPages = ImmutableMap<GroupVersionKind | string, () => P
   .set(referenceForModel(StorageClassModel), () => import('./storage-class' /* webpackChunkName: "storage-class" */).then(m => m.StorageClassPage))
   .set(referenceForModel(CustomResourceDefinitionModel), () => import('./custom-resource-definition' /* webpackChunkName: "custom-resource-definition" */).then(m => m.CustomResourceDefinitionsPage))
   .set(referenceForModel(VirtualMachineModel), () => import('../kubevirt/components/vm' /* webpackChunkName: "virtual-machines" */).then(m => m.VirtualMachinesPage))
+  .set(referenceForModel(VmTemplateModel), () => import('../kubevirt/components/vm-template' /* webpackChunkName: "vm-templates" */).then(m => m.VirtualMachineTemplatesPage))
   .set(referenceForModel(ClusterServiceVersionModel), () => import('./operator-lifecycle-manager/clusterserviceversion' /* webpackChunkName: "clusterserviceversion" */).then(m => m.ClusterServiceVersionsPage))
   .set(referenceForModel(PackageManifestModel), () => import('./operator-lifecycle-manager/package-manifest' /* webpackChunkName: "package-manifest" */).then(m => m.PackageManifestsPage))
   .set(referenceForModel(SubscriptionModel), () => import('./operator-lifecycle-manager/subscription' /* webpackChunkName: "subscription" */).then(m => m.SubscriptionsPage))

--- a/frontend/public/kubevirt/components/nav.jsx
+++ b/frontend/public/kubevirt/components/nav.jsx
@@ -8,6 +8,7 @@ import { FLAGS } from '../../features';
 import { NavSection, ClusterPickerNavSection, UserNavSection } from './okdcomponents';
 import { ChargebackReportModel, DeploymentConfigModel } from '../models';
 import { referenceForModel } from '../module/okdk8s';
+import { VmTemplatesPageTitle } from './vm-template';
 
 // With respect to keep changes to OKD codebase at bare minimum,
 // the navigation needs to be reconstructed.
@@ -34,6 +35,7 @@ const Nav = ({ isOpen, onToggle, close, scroller, onWheel, searchStartsWith, Res
 
           <NavSection text="Workloads" icon="fa fa-folder-open-o">
             <ResourceNSLink resource="virtualmachines" name="Virtual Machines" onClick={close} />
+            <ResourceNSLink resource="vmtemplates" name={VmTemplatesPageTitle} onClick={close} />
 
             <ResourceNSLink resource="pods" name="Pods" onClick={close} />
             <ResourceNSLink resource="deployments" name="Deployments" onClick={close} />

--- a/frontend/public/kubevirt/components/vm-template.jsx
+++ b/frontend/public/kubevirt/components/vm-template.jsx
@@ -1,0 +1,40 @@
+import React from 'react';
+import * as _ from 'lodash';
+import { VmTemplateModel } from '../models';
+import { ListPage, List, ResourceRow, ListHeader, ColHead } from './factory/okdfactory';
+import { ResourceLink, ResourceKebab, Kebab } from './utils/okdutils';
+import { DASHES } from './utils/constants';
+
+const menuActions = [Kebab.factory.Delete];
+const nameRowStyle = 'col-lg-2 col-md-2 col-sm-2 col-xs-6';
+const descriptionRowStyle = 'col-lg-10 col-md-10 col-sm-10 col-xs-6';
+
+const VmTemplateHeader = props => <ListHeader>
+  <ColHead {...props} className={nameRowStyle} sortField="metadata.name">Name</ColHead>
+  <ColHead {...props} className={descriptionRowStyle} sortField="metadata.annotations.description">Description</ColHead>
+</ListHeader>;
+
+const VmTemplateRow = ({obj: template}) => <ResourceRow obj={template}>
+  <div className={nameRowStyle}>
+    <ResourceLink kind={VmTemplateModel.kind} name={template.metadata.name} namespace={template.metadata.namespace} title={template.metadata.uid} />
+  </div>
+  <div className={descriptionRowStyle}>
+    {_.get(template.metadata, 'annotations.description', DASHES)}
+  </div>
+  <div className="co-kebab-wrapper">
+    <ResourceKebab actions={menuActions} kind={VmTemplateModel.kind} resource={template} />
+  </div>
+</ResourceRow>;
+
+
+const VmTemplateList = props => <List {...props} Header={VmTemplateHeader} Row={VmTemplateRow} />;
+
+export const VmTemplatesPageTitle = 'Virtual Machine Templates';
+
+export const VirtualMachineTemplatesPage = props => <ListPage
+  {...props}
+  title={VmTemplatesPageTitle}
+  selector={VmTemplateModel.selector}
+  kind={VmTemplateModel.kind}
+  ListComponent={VmTemplateList}
+/>;

--- a/frontend/public/kubevirt/models/vm.ts
+++ b/frontend/public/kubevirt/models/vm.ts
@@ -1,5 +1,6 @@
 // eslint-disable-next-line no-unused-vars
 import { K8sKind } from '../../module/k8s';
+import { TEMPLATE_TYPE_LABEL } from 'kubevirt-web-ui-components';
 
 export const VirtualMachineModel: K8sKind = {
   label: 'Virtual Machine',
@@ -51,6 +52,22 @@ export const TemplateModel: K8sKind = {
   abbr: 'Template',
   kind: 'Template',
   id: 'template',
+};
+
+export const VmTemplateModel: K8sKind = {
+  label: 'Template',
+  labelPlural: 'Templates',
+  apiVersion: 'v1',
+  path: 'templates',
+  apiGroup: 'template.openshift.io',
+  plural: 'templates',
+  namespaced: true,
+  abbr: 'VMT',
+  kind: 'Template',
+  id: 'vmtemplate',
+  selector: {
+    matchLabels: {[TEMPLATE_TYPE_LABEL]: 'vm'},
+  },
 };
 
 export const NetworkAttachmentDefinitionModel: K8sKind = {


### PR DESCRIPTION
![vmtemplates](https://user-images.githubusercontent.com/2078045/48709025-8b8b8100-ec04-11e8-93cd-244b3ff4b33e.png)

list now contains only template name and description. I will add more rows once we have create template dialog and we are clear on how to represent source/os/flavor etc