### PR TITLE
[OKD-core] models: Finish co-locating kubevirt code

### DIFF
--- a/frontend/public/models/index.ts
+++ b/frontend/public/models/index.ts
@@ -775,44 +775,6 @@ export const ServiceBindingModel: K8sKind = {
 };
 
 export * from '../kubevirt/models/vm'; // needed when setting features and resource pages
-export const VirtualMachineModel: K8sKind = {
-  label: 'Virtual Machine',
-  labelPlural: 'Virtual Machines',
-  apiVersion: 'v1alpha2',
-  path: 'virtualmachines',
-  apiGroup: 'kubevirt.io',
-  plural: 'virtualmachines',
-  abbr: 'VM',
-  namespaced: true,
-  kind: 'VirtualMachine',
-  id: 'virtualmachine',
-};
-
-export const VirtualMachineInstanceModel: K8sKind = {
-  label: 'Virtual Machine Instance',
-  labelPlural: 'Virtual Machine Instances',
-  apiVersion: 'v1alpha2',
-  path: 'virtualmachineinstances',
-  apiGroup: 'kubevirt.io',
-  plural: 'virtualmachineinstances',
-  abbr: 'VMI',
-  namespaced: true,
-  kind: 'VirtualMachineInstance',
-  id: 'virtualmachineinstance',
-};
-
-export const VirtualMachineInstancePresetModel: K8sKind = {
-  label: 'Virtual Machine Instance Preset',
-  labelPlural: 'Virtual Machine Instance Presets',
-  apiVersion: 'v1alpha2',
-  path: 'virtualmachineinstancepresets',
-  apiGroup: 'kubevirt.io',
-  plural: 'virtualmachineinstancepresets',
-  abbr: 'VMIP',
-  namespaced: true,
-  kind: 'VirtualMachineInstancePreset',
-  id: 'virtualmachineinstancepreset',
-};
 
 export const LimitRangeModel: K8sKind = {
   label: 'Limit Range',


### PR DESCRIPTION
Kubevirt-related models were moved to `frontend/public/kubevirt/models/vm.ts`
by a former patch.

By mistake, a copy of the models remained
in OKD-core `frontend/public/models/index.ts`.