### PR TITLE
Add DesktopViewer among other consoles

### DIFF
--- a/frontend/public/kubevirt/components/utils/constants.js
+++ b/frontend/public/kubevirt/components/utils/constants.js
@@ -10,3 +10,5 @@ export const DISK = 'Disk';
 
 export const VIRT_LAUNCHER_POD_PREFIX = 'virt-launcher-';
 export const IMPORTER_DV_POD_PREFIX = 'importer-datavolume-';
+
+export const DEFAULT_RDP_PORT = 3389;

--- a/frontend/public/kubevirt/components/utils/constants.js
+++ b/frontend/public/kubevirt/components/utils/constants.js
@@ -10,5 +10,3 @@ export const DISK = 'Disk';
 
 export const VIRT_LAUNCHER_POD_PREFIX = 'virt-launcher-';
 export const IMPORTER_DV_POD_PREFIX = 'importer-datavolume-';
-
-export const DEFAULT_RDP_PORT = 3389;

--- a/frontend/public/kubevirt/components/utils/resources.js
+++ b/frontend/public/kubevirt/components/utils/resources.js
@@ -42,9 +42,12 @@ export const findVMIMigration = (data, vmiName) => {
 const findPortOfService = (service, targetPort) => _.get(service, ['spec', 'ports'], [])
   .find(servicePort => targetPort === servicePort.targetPort);
 
+/*
+ See web-ui-components, request.js:addMetadata() for automatic VM name label addition to match the selector
+ */
 const findVMServiceWithPort = (vmi, allServices, targetPort) => (allServices || [])
   .find(service =>
-    vmi.metadata.name === _.get(service, ['spec', 'selector', TEMPLATE_VM_NAME_LABEL])
+    vmi && vmi.metadata && vmi.metadata.name === _.get(service, ['spec', 'selector', TEMPLATE_VM_NAME_LABEL])
     && !!findPortOfService(service, targetPort)
   );
 

--- a/frontend/public/kubevirt/components/utils/resources.js
+++ b/frontend/public/kubevirt/components/utils/resources.js
@@ -4,8 +4,7 @@ import { getCSRFToken } from '../../../co-fetch';
 import { k8sBasePath } from '../../module/okdk8s';
 
 import { VirtualMachineInstanceMigrationModel, VirtualMachineInstanceModel, PodModel } from '../../models';
-import { DEFAULT_RDP_PORT } from './constants';
-import { TEMPLATE_VM_NAME_LABEL } from 'kubevirt-web-ui-components';
+import { TEMPLATE_VM_NAME_LABEL, DEFAULT_RDP_PORT } from 'kubevirt-web-ui-components';
 
 export const getResourceKind = (model, name, namespaced, namespace, isList, matchLabels, matchExpressions) => {
   const res = { kind:model.kind, namespaced, namespace, isList, prop: model.kind};

--- a/frontend/public/kubevirt/components/utils/resources.js
+++ b/frontend/public/kubevirt/components/utils/resources.js
@@ -73,6 +73,12 @@ export const getVncConnectionDetails = vmi => {
 
     // Example: ws://localhost:9000/api/kubernetes/apis/subresources.kubevirt.io/v1alpha2/namespaces/kube-system/virtualmachineinstances/vm-cirros1/vnc
     path: `${getConsoleApiContext()}/${getConsoleApiPath(vmi)}/vnc${getConsoleApiQuery()}`,
+
+    manual: {
+      address: 'Service not exposed',
+      port: undefined,
+      tlsPort: undefined,
+    },
   };
 };
 
@@ -84,3 +90,14 @@ export const getSerialConsoleConnectionDetails = vmi => {
     path: `/${getConsoleApiContext()}/${getConsoleApiPath(vmi)}/console`, // CSRF Token will be added in WSFactory
   };
 };
+
+export const getRdpConnectionDetails = vmi => {
+  return {
+    vmi,
+
+    manual: {
+      address: 'RDP Service not exposed',
+    },
+  };
+};
+

--- a/frontend/public/kubevirt/components/utils/resources.js
+++ b/frontend/public/kubevirt/components/utils/resources.js
@@ -3,6 +3,8 @@ import { getCSRFToken } from '../../../co-fetch';
 import { k8sBasePath } from '../../module/okdk8s';
 
 import { VirtualMachineInstanceMigrationModel, VirtualMachineInstanceModel, PodModel } from '../../models';
+import { DEFAULT_RDP_PORT } from './constants';
+import { TEMPLATE_VM_NAME_LABEL } from 'kubevirt-web-ui-components';
 
 export const getResourceKind = (model, name, namespaced, namespace, isList, matchLabels, matchExpressions) => {
   const res = { kind:model.kind, namespaced, namespace, isList, prop: model.kind};
@@ -37,6 +39,15 @@ export const findVMIMigration = (data, vmiName) => {
   return migrations.find(m => !_.get(m, 'status.completed') && !_.get(m, 'status.failed') );
 };
 
+const findPortOfService = (service, targetPort) => _.get(service, ['spec', 'ports'], [])
+  .find(servicePort => targetPort === servicePort.targetPort);
+
+const findVMServiceWithPort = (vmi, allServices, targetPort) => (allServices || [])
+  .find(service =>
+    vmi.metadata.name === _.get(service, ['spec', 'selector', TEMPLATE_VM_NAME_LABEL])
+    && !!findPortOfService(service, targetPort)
+  );
+
 export const getFlattenForKind = (kind) => {
   return resources => _.get(resources, kind, {}).data;
 };
@@ -65,6 +76,10 @@ const getConsoleApiQuery = () => `?x-csrf-token=${encodeURIComponent(getCSRFToke
 const isEncrypted = () => window.location.protocol === 'https:';
 
 export const getVncConnectionDetails = vmi => {
+  if (!vmi) {
+    return undefined;
+  }
+
   // the novnc library requires protocol to be specified so the URL must be absolute - including host:port
   return {
     encrypt: isEncrypted(), // whether ws or wss to be used
@@ -74,15 +89,22 @@ export const getVncConnectionDetails = vmi => {
     // Example: ws://localhost:9000/api/kubernetes/apis/subresources.kubevirt.io/v1alpha2/namespaces/kube-system/virtualmachineinstances/vm-cirros1/vnc
     path: `${getConsoleApiContext()}/${getConsoleApiPath(vmi)}/vnc${getConsoleApiQuery()}`,
 
-    manual: {
+    manual: undefined, // so far unsupported
+    /* TODO: Desktop viewer connection needs general agreement by the Kubevirt community how to expose the VNC port for clients without WS
+      {
       address: 'Service not exposed',
       port: undefined,
       tlsPort: undefined,
     },
+    */
   };
 };
 
 export const getSerialConsoleConnectionDetails = vmi => {
+  if (!vmi) {
+    return undefined;
+  }
+
   const protocol = window.location.protocol === 'https:' ? 'wss' : 'ws';
   return {
     vmi,
@@ -91,13 +113,73 @@ export const getSerialConsoleConnectionDetails = vmi => {
   };
 };
 
-export const getRdpConnectionDetails = vmi => {
+/* eslint no-console: ["warn", { allow: ["log"] }] */
+const getRdpAddressPort = (rdpService, launcherPod) => {
+  const rdpPortObj = findPortOfService(rdpService, DEFAULT_RDP_PORT);
+  if (!rdpPortObj) {
+    return null;
+  }
+
+  const port = _.get(rdpPortObj, 'port');
+  let address;
+  switch (_.get(rdpService, 'spec.type')) {
+    case 'LoadBalancer':
+      address = _.get(rdpService, 'spec.externalIPs[0]');
+      if (!address) {
+        console.warn('External IP is not defined for the LoadBalancer RDP Service: ', rdpService);
+      }
+      break;
+    case 'ClusterIP':
+      address = _.get(rdpService, 'spec.clusterIP');
+      if (!address) {
+        console.warn('Cluster IP is not defined for the ClusterIP RDP Service: ', rdpService);
+      }
+      break;
+    case 'NodePort':
+      if (launcherPod) {
+        address = _.get(launcherPod, 'status.hostIP');
+      }
+      if (!address) {
+        console.warn('Node IP (launcherpod.status.hostIP) is not yet known for NodePort RDP Service: ', rdpService);
+      }
+      break;
+    default:
+      console.error('Unrecognized Service type: ', rdpService);
+  }
+
+  if (!address) {
+    return null;
+  }
+
+  console.log('RDP requested for: ', address, port);
+  return {
+    address,
+    port,
+  };
+};
+
+/**
+ * Finds Service for the VM/VMI which is exposing the RDP port.
+ * Returns undefined or single first match.
+ *
+ * To pair service with VM, selector must be set on the Service object:
+ *   spec:
+ *     selector:
+ *       vm.cnv.io/name: VM_NAME
+ *
+ * https://kubevirt.io/user-guide/docs/latest/using-virtual-machines/expose-service.html
+ * virtctl expose virtualmachine [VM_NAME] --name [MY_SERVICE_NAME] --port 27017 --target-port 3389
+ */
+export const findRDPService = (vmi, allServices) => findVMServiceWithPort(vmi, allServices, DEFAULT_RDP_PORT);
+
+export const getRdpConnectionDetails = (vmi, rdpService, launcherPod) => {
+  if (!vmi || !rdpService) {
+    return undefined;
+  }
+
   return {
     vmi,
-
-    manual: {
-      address: 'RDP Service not exposed',
-    },
+    manual: getRdpAddressPort(rdpService, launcherPod),
   };
 };
 

--- a/frontend/public/kubevirt/components/utils/resources.js
+++ b/frontend/public/kubevirt/components/utils/resources.js
@@ -1,3 +1,4 @@
+/* eslint-disable no-console */
 import * as _ from 'lodash-es';
 import { getCSRFToken } from '../../../co-fetch';
 import { k8sBasePath } from '../../module/okdk8s';
@@ -47,7 +48,7 @@ const findPortOfService = (service, targetPort) => _.get(service, ['spec', 'port
  */
 const findVMServiceWithPort = (vmi, allServices, targetPort) => (allServices || [])
   .find(service =>
-    vmi && vmi.metadata && vmi.metadata.name === _.get(service, ['spec', 'selector', TEMPLATE_VM_NAME_LABEL])
+    _.get(vmi, 'metadata.name') === _.get(service, ['spec', 'selector', TEMPLATE_VM_NAME_LABEL])
     && !!findPortOfService(service, targetPort)
   );
 
@@ -116,7 +117,6 @@ export const getSerialConsoleConnectionDetails = vmi => {
   };
 };
 
-/* eslint no-console: ["warn", { allow: ["log"] }] */
 const getRdpAddressPort = (rdpService, launcherPod) => {
   const rdpPortObj = findPortOfService(rdpService, DEFAULT_RDP_PORT);
   if (!rdpPortObj) {

--- a/frontend/public/kubevirt/components/vmconsoles.jsx
+++ b/frontend/public/kubevirt/components/vmconsoles.jsx
@@ -1,4 +1,4 @@
-import React, { Fragment } from 'react';
+import React from 'react';
 
 import {
   getResourceKind,
@@ -35,16 +35,14 @@ const VmConsoles_ = ({ vm, vmi, services, pods }) => {
     rdp = getRdpConnectionDetails(vmi, rdpService, launcherPod);
   }
 
-  return <Fragment>
-    <VmConsoles vm={vm}
-      vmi={vmi}
-      onStartVm={onStartVm}
-      vnc={getVncConnectionDetails(vmi)}
-      serial={getSerialConsoleConnectionDetails(vmi)}
-      rdp={rdp}
-      LoadingComponent={LoadingInline}
-      WSFactory={WSFactory} />
-  </Fragment>;
+  return <VmConsoles vm={vm}
+    vmi={vmi}
+    onStartVm={onStartVm}
+    vnc={getVncConnectionDetails(vmi)}
+    serial={getSerialConsoleConnectionDetails(vmi)}
+    rdp={rdp}
+    LoadingComponent={LoadingInline}
+    WSFactory={WSFactory} />;
 };
 
 /**

--- a/frontend/public/kubevirt/components/vmconsoles.jsx
+++ b/frontend/public/kubevirt/components/vmconsoles.jsx
@@ -27,9 +27,9 @@ const FirehoseVmConsoles = props => {
   return <VmConsoles vm={vm}
     vmi={vmi}
     onStartVm={onStartVm}
-    getVncConnectionDetails={getVncConnectionDetails}
-    getSerialConsoleConnectionDetails={getSerialConsoleConnectionDetails}
-    getRdpConnectionDetails={getRdpConnectionDetails}
+    vnc={getVncConnectionDetails(vmi)}
+    serial={getSerialConsoleConnectionDetails(vmi)}
+    rdp={getRdpConnectionDetails(vmi)}
     LoadingComponent={LoadingInline}
     WSFactory={WSFactory} />;
 };

--- a/frontend/public/kubevirt/components/vmconsoles.jsx
+++ b/frontend/public/kubevirt/components/vmconsoles.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import { getResourceKind, getVncConnectionDetails, getSerialConsoleConnectionDetails, getFlattenForKind } from './utils/resources';
+import { getLabelMatcher, getResourceKind, getVncConnectionDetails, getSerialConsoleConnectionDetails, getRdpConnectionDetails, getFlattenForKind, findVMI } from './utils/resources';
 
 import { Firehose } from './utils/okdutils';
 import { LoadingInline } from './okdcomponents';
@@ -24,7 +24,14 @@ const FirehoseVmConsoles = props => {
     start: true,
   });
 
-  return <VmConsoles vm={vm} vmi={vmi} onStartVm={onStartVm} getVncConnectionDetails={getVncConnectionDetails} getSerialConsoleConnectionDetails={getSerialConsoleConnectionDetails} LoadingComponent={LoadingInline} WSFactory={WSFactory} />;
+  return <VmConsoles vm={vm}
+    vmi={vmi}
+    onStartVm={onStartVm}
+    getVncConnectionDetails={getVncConnectionDetails}
+    getSerialConsoleConnectionDetails={getSerialConsoleConnectionDetails}
+    getRdpConnectionDetails={getRdpConnectionDetails}
+    LoadingComponent={LoadingInline}
+    WSFactory={WSFactory} />;
 };
 
 /**

--- a/frontend/public/kubevirt/components/vmconsoles.jsx
+++ b/frontend/public/kubevirt/components/vmconsoles.jsx
@@ -1,49 +1,76 @@
-import React from 'react';
+import React, { Fragment } from 'react';
 
-import { getLabelMatcher, getResourceKind, getVncConnectionDetails, getSerialConsoleConnectionDetails, getRdpConnectionDetails, getFlattenForKind, findVMI } from './utils/resources';
+import {
+  getResourceKind,
+  getVncConnectionDetails,
+  getSerialConsoleConnectionDetails,
+  getRdpConnectionDetails,
+  findRDPService, getLabelMatcher, findPod,
+} from './utils/resources';
 
-import { Firehose } from './utils/okdutils';
+import { VmConsoles, isWindows } from 'kubevirt-web-ui-components';
 import { LoadingInline } from './okdcomponents';
 import { WSFactory } from '../module/okdk8s';
-
-import { VirtualMachineInstanceModel, VirtualMachineModel } from '../models';
 import { startStopVmModal } from './modals/start-stop-vm-modal';
+import { WithResources } from './utils/withResources';
 
-import { VmConsoles } from 'kubevirt-web-ui-components';
+import {
+  VirtualMachineInstanceModel,
+  VirtualMachineModel,
+  ServiceModel, PodModel,
+} from '../models';
+import { VIRT_LAUNCHER_POD_PREFIX } from './utils/constants';
 
-/**
- * Helper component to keep VmConsoles dependent on VMI only.
- */
-const FirehoseVmConsoles = props => {
-  const vmi = props.flatten(props.resources);
-  const vm = props.vm;
-
+const VmConsoles_ = ({ vm, vmi, services, pods }) => {
   const onStartVm = () => startStopVmModal({
     kind: VirtualMachineModel,
     resource: vm,
     start: true,
   });
 
-  return <VmConsoles vm={vm}
-    vmi={vmi}
-    onStartVm={onStartVm}
-    vnc={getVncConnectionDetails(vmi)}
-    serial={getSerialConsoleConnectionDetails(vmi)}
-    rdp={getRdpConnectionDetails(vmi)}
-    LoadingComponent={LoadingInline}
-    WSFactory={WSFactory} />;
+  let rdp;
+  if (isWindows(vm)) {
+    const rdpService = findRDPService(vmi, services);
+    const launcherPod = findPod(pods, vm.metadata.name, VIRT_LAUNCHER_POD_PREFIX);
+    rdp = getRdpConnectionDetails(vmi, rdpService, launcherPod);
+  }
+
+  return <Fragment>
+    <VmConsoles vm={vm}
+      vmi={vmi}
+      onStartVm={onStartVm}
+      vnc={getVncConnectionDetails(vmi)}
+      serial={getSerialConsoleConnectionDetails(vmi)}
+      rdp={rdp}
+      LoadingComponent={LoadingInline}
+      WSFactory={WSFactory} />;
+  </Fragment>;
 };
 
 /**
  * Wrapper for VmConsoles performing asynchronous loading of API resources.
  */
-const VmConsolesConnected = ({ obj: vm }) => {
-  const vmiResource = getResourceKind(VirtualMachineInstanceModel, vm.metadata.name, true, vm.metadata.namespace, false);
+const ConnectedVmConsoles = ({ obj: vm }) => {
+  const resourceMap = {
+    vmi: {
+      resource: getResourceKind(VirtualMachineInstanceModel, vm.metadata.name, true, vm.metadata.namespace, false),
+      ignoreErrors: true,
+    },
+    services: {
+      // We probably can not simply match on labels but on Service's spec.selector.[kubevirt/vm] to achieve robust pairing VM-Service.
+      // So read all services and filter on frontend.
+      resource: getResourceKind(ServiceModel, undefined, true, vm.metadata.namespace, true),
+    },
+    pods: {
+      resource: getResourceKind(PodModel, undefined, true, vm.metadata.namespace, true, getLabelMatcher(vm)),
+    },
+  };
+
   return (
-    <Firehose resources={[vmiResource]} flatten={getFlattenForKind(VirtualMachineInstanceModel.kind)}>
-      <FirehoseVmConsoles vm={vm} />
-    </Firehose>
+    <WithResources resourceMap={resourceMap}>
+      <VmConsoles_ vm={vm} />
+    </WithResources>
   );
 };
 
-export default VmConsolesConnected;
+export default ConnectedVmConsoles;

--- a/frontend/public/kubevirt/components/vmconsoles.jsx
+++ b/frontend/public/kubevirt/components/vmconsoles.jsx
@@ -43,7 +43,7 @@ const VmConsoles_ = ({ vm, vmi, services, pods }) => {
       serial={getSerialConsoleConnectionDetails(vmi)}
       rdp={rdp}
       LoadingComponent={LoadingInline}
-      WSFactory={WSFactory} />;
+      WSFactory={WSFactory} />
   </Fragment>;
 };
 


### PR DESCRIPTION
VM console can be accessed via desktop-based viewer application.

TODO:
- [ ] have https://github.com/kubevirt/web-ui-components/pull/127 merged
- [x] locate exposed VM's VNC/RDP service, render conditionally
- [x] link/write documentation to expose VM's console as a service