### PR TITLE
Hide VM migration menu items.

### DIFF
--- a/frontend/public/kubevirt/components/vm/menu-actions.jsx
+++ b/frontend/public/kubevirt/components/vm/menu-actions.jsx
@@ -44,6 +44,7 @@ const menuActionRestart = (kind, vm) => ({
   }),
 });
 
+// eslint-disable-next-line no-unused-vars
 const menuActionCancelMigration = (kind, vm, actionArgs) => {
   const migration = findVMIMigration(actionArgs[VirtualMachineInstanceMigrationModel.kind], _.get(actionArgs[VirtualMachineInstanceModel.kind], 'metadata.name'));
   return {
@@ -55,6 +56,7 @@ const menuActionCancelMigration = (kind, vm, actionArgs) => {
   };
 };
 
+// eslint-disable-next-line no-unused-vars
 const menuActionMigrate = (kind, vm, actionArgs) => {
   const migration = findVMIMigration(actionArgs[VirtualMachineInstanceMigrationModel.kind], _.get(actionArgs[VirtualMachineInstanceModel.kind], 'metadata.name'));
   const { name, namespace } = vm.metadata;
@@ -77,4 +79,4 @@ const menuActionMigrate = (kind, vm, actionArgs) => {
 };
 
 
-export const menuActions = [menuActionStart, menuActionRestart, menuActionMigrate, menuActionCancelMigration, Kebab.factory.Delete];
+export const menuActions = [menuActionStart, menuActionRestart, Kebab.factory.Delete];


### PR DESCRIPTION
We have to disable migration for 1.4. See https://bugzilla.redhat.com/show_bug.cgi?id=1666330