### PR TITLE
Fixed status checking to include status icon

### DIFF
--- a/frontend/integration-tests/tests/kubevirt/utils.ts
+++ b/frontend/integration-tests/tests/kubevirt/utils.ts
@@ -3,10 +3,10 @@ import { execSync } from 'child_process';
 import { $, by, ElementFinder } from 'protractor';
 
 export const PAGE_LOAD_TIMEOUT = 5000;
-export const VM_WIZARD_LOAD_TIMEOUT = 10000;
-export const VM_BOOTUP_TIMEOUT = 60000;
+export const WIZARD_LOAD_TIMEOUT = 10000;
+export const VM_ACTIONS_TIMEOUT = 120000;
+export const VM_BOOTUP_TIMEOUT = 90000;
 export const VM_STOP_TIMEOUT = 6000;
-export const VM_ACTIONS_TIMEOUT = 90000;
 
 export type provision = {
   method: string,

--- a/frontend/integration-tests/tests/kubevirt/vm.actions.scenario.ts
+++ b/frontend/integration-tests/tests/kubevirt/vm.actions.scenario.ts
@@ -4,15 +4,10 @@ import { browser, ExpectedConditions as until } from 'protractor';
 
 import { appHost, testName } from '../../protractor.conf';
 import { filterForName, isLoaded, resourceRowsPresent } from '../../views/crud.view';
+import { detailViewAction, listViewAction, detailViewVmStatus, detailViewVmIcon, listViewVmStatus, listViewVmIcon,
+  runningIcon, pendingIcon, statusIcon, offIcon } from '../../views/kubevirt/vm.actions.view';
 import { testVM } from './mocks';
-import { removeLeakedResources } from './utils';
-import { detailViewAction, detailViewVmStatus, listViewAction, listViewVmStatus,
-  listViewVmIcon, detailViewVmIcon, runningIcon, offIcon, pendingIcon, statusIcon } from '../../views/kubevirt/vm.actions.view';
-
-
-const VM_BOOTUP_TIMEOUT = 60000;
-const VM_ACTIONS_TIMEOUT = 90000;
-const VM_STOP_TIMEOUT = 6000;
+import { removeLeakedResources, VM_BOOTUP_TIMEOUT, VM_STOP_TIMEOUT, VM_ACTIONS_TIMEOUT } from './utils';
 
 describe('Test VM actions', () => {
   const leakedResources = new Set<string>();
@@ -110,7 +105,7 @@ describe('Test VM actions', () => {
 
     it('Stops VM', async() => {
       await detailViewAction('Stop');
-      await browser.wait(until.and(until.presenceOf(detailViewVmIcon(offIcon))), VM_STOP_TIMEOUT);
+      await browser.wait(until.presenceOf(detailViewVmIcon(offIcon)), VM_STOP_TIMEOUT);
     });
 
     it('Deletes VM', async() => {

--- a/frontend/integration-tests/views/kubevirt/vm.actions.view.ts
+++ b/frontend/integration-tests/views/kubevirt/vm.actions.view.ts
@@ -1,8 +1,16 @@
 import { $, $$, browser, ExpectedConditions as until } from 'protractor';
 import { rowForName, confirmAction } from '../crud.view';
 
-export const detailViewVMmStatus = $('#details-column-1 .kubevirt-vm-status__link');
-export const listViewVMmStatus = (name: string) => rowForName(name).$('.kubevirt-vm-status__link');
+export const detailViewVmStatus = $('#details-column-1 .kubevirt-vm-status__link');
+export const detailViewVmIcon = (statusIcon: string) => $('#details-column-1').$(statusIcon);
+
+export const listViewVmStatus = (name: string) => rowForName(name).$('.kubevirt-vm-status__link');
+export const listViewVmIcon = (name: string, statusIcon: string) => rowForName(name).$(statusIcon);
+
+export const statusIcon = 'kubevirt-vm-status__icon';
+export const runningIcon = '.pficon-on-running';
+export const offIcon = '.pficon-off';
+export const pendingIcon = '.pficon-pending';
 
 const listViewKebabDropdown = '.co-kebab__button';
 const listViewKebabDropdownMenu = '.co-kebab__dropdown';

--- a/frontend/integration-tests/views/kubevirt/vm.actions.view.ts
+++ b/frontend/integration-tests/views/kubevirt/vm.actions.view.ts
@@ -7,7 +7,7 @@ export const detailViewVmIcon = (statusIcon: string) => $('#details-column-1').$
 export const listViewVmStatus = (name: string) => rowForName(name).$('.kubevirt-vm-status__link');
 export const listViewVmIcon = (name: string, statusIcon: string) => rowForName(name).$(statusIcon);
 
-export const statusIcon = 'kubevirt-vm-status__icon';
+export const statusIcon = '.kubevirt-vm-status__icon';
 export const runningIcon = '.pficon-on-running';
 export const offIcon = '.pficon-off';
 export const pendingIcon = '.pficon-pending';


### PR DESCRIPTION
Fixed status checking to include status icon. Stopped VM status now only checks the icon as the status text is not a link.