### PR TITLE
Introduce base for hosts listing page

### DIFF
--- a/frontend/__tests__/features.spec.tsx
+++ b/frontend/__tests__/features.spec.tsx
@@ -45,6 +45,7 @@ describe('featureReducer', () => {
       [FLAGS.OPERATOR_HUB]: false,
       [FLAGS.CLUSTER_API]: false,
       [FLAGS.MACHINE_CONFIG]: false,
+      [FLAGS.METALKUBE]: false,
     }));
   });
 });

--- a/frontend/public/components/resource-pages.ts
+++ b/frontend/public/components/resource-pages.ts
@@ -6,6 +6,7 @@ import { ReportReference, ReportGenerationQueryReference } from './chargeback';
 import { referenceForModel, GroupVersionKind } from '../module/k8s';
 import {
   AlertmanagerModel,
+  BaremetalHostModel,
   BuildConfigModel,
   BuildModel,
   CatalogSourceModel,
@@ -166,6 +167,7 @@ export const resourceListPages = ImmutableMap<GroupVersionKind | string, () => P
   .set(referenceForModel(StorageClassModel), () => import('./storage-class' /* webpackChunkName: "storage-class" */).then(m => m.StorageClassPage))
   .set(referenceForModel(CustomResourceDefinitionModel), () => import('./custom-resource-definition' /* webpackChunkName: "custom-resource-definition" */).then(m => m.CustomResourceDefinitionsPage))
   .set(referenceForModel(VirtualMachineModel), () => import('../kubevirt/components/vm' /* webpackChunkName: "virtual-machines" */).then(m => m.VirtualMachinesPage))
+  .set(referenceForModel(BaremetalHostModel), () => import('../metalkube/components/host/host' /* webpackChunkName: "baremetal-hosts" */).then(m => m.BaremetalHostsPage))
   .set(referenceForModel(ClusterServiceVersionModel), () => import('./operator-lifecycle-manager/clusterserviceversion' /* webpackChunkName: "clusterserviceversion" */).then(m => m.ClusterServiceVersionsPage))
   .set(referenceForModel(PackageManifestModel), () => import('./operator-lifecycle-manager/package-manifest' /* webpackChunkName: "package-manifest" */).then(m => m.PackageManifestsPage))
   .set(referenceForModel(SubscriptionModel), () => import('./operator-lifecycle-manager/subscription' /* webpackChunkName: "subscription" */).then(m => m.SubscriptionsPage))

--- a/frontend/public/features.ts
+++ b/frontend/public/features.ts
@@ -14,6 +14,7 @@ import {
   PrometheusModel,
   SelfSubjectAccessReviewModel,
   VirtualMachineModel,
+  BaremetalHostModel,
 } from './models';
 import { ClusterVersionKind } from './module/k8s';
 import { k8sBasePath, referenceForModel } from './module/k8s/k8s';
@@ -44,6 +45,7 @@ import { UIActions } from './ui/ui-actions';
   CLUSTER_API: false,
   CLUSTER_VERSION: false,
   MACHINE_CONFIG: false,
+  METALKUBE: false,
  */
 export enum FLAGS {
   AUTH_ENABLED = 'AUTH_ENABLED',
@@ -60,6 +62,7 @@ export enum FLAGS {
   CAN_LIST_MACHINE_CONFIG = 'CAN_LIST_MACHINE_CONFIG',
   CAN_CREATE_PROJECT = 'CAN_CREATE_PROJECT',
   KUBEVIRT = 'KUBEVIRT',
+  METALKUBE = 'METALKUBE',
   SHOW_OPENSHIFT_START_GUIDE = 'SHOW_OPENSHIFT_START_GUIDE',
   SERVICE_CATALOG = 'SERVICE_CATALOG',
   OPERATOR_HUB = 'OPERATOR_HUB',
@@ -82,6 +85,7 @@ export const CRDs = {
   [referenceForModel(OperatorSourceModel)]: FLAGS.OPERATOR_HUB,
   [referenceForModel(MachineModel)]: FLAGS.CLUSTER_API,
   [referenceForModel(MachineConfigModel)]: FLAGS.MACHINE_CONFIG,
+  [referenceForModel(BaremetalHostModel)]: FLAGS.METALKUBE,
 };
 
 const SET_FLAG = 'SET_FLAG';

--- a/frontend/public/kubevirt/components/nav.jsx
+++ b/frontend/public/kubevirt/components/nav.jsx
@@ -78,6 +78,7 @@ const PageNav = ({ onNavSelect, ResourceClusterLink, HrefLink, ResourceNSLink, M
       <NavSection title="Administration">
         <ResourceClusterLink resource="namespaces" name="Namespaces" required={FLAGS.CAN_LIST_NS} />
         <ResourceClusterLink resource="nodes" name="Nodes" required={FLAGS.CAN_LIST_NODE} />
+        <ResourceNSLink resource="baremetalhosts" name="Bare Metal Hosts" required={FLAGS.METALKUBE} />
         <ResourceNSLink resource={referenceForModel(MachineSetModel)} name="Machine Sets" required={FLAGS.CLUSTER_API} />
         <ResourceNSLink resource={referenceForModel(MachineModel)} name="Machines" required={FLAGS.CLUSTER_API} />
         <HrefLink href="/settings/cluster" activePath="/settings/cluster/" name="Cluster Settings" required={FLAGS.CLUSTER_VERSION} />

--- a/frontend/public/metalkube/components/factory/okdfactory.tsx
+++ b/frontend/public/metalkube/components/factory/okdfactory.tsx
@@ -1,0 +1,2 @@
+// indirect reuse of OKD in kubevirt
+export * from '../../../components/factory';

--- a/frontend/public/metalkube/components/host/host.tsx
+++ b/frontend/public/metalkube/components/host/host.tsx
@@ -1,0 +1,97 @@
+import * as React from 'react';
+
+import {
+  ListHeader,
+  ColHead,
+  List,
+  ListPage,
+  ResourceRow,
+} from '../factory/okdfactory';
+import { BaremetalHostModel } from '../../models/host';
+import { ResourceLink } from '../utils/okdutils';
+import { NamespaceModel } from '../../models/index';
+
+const mainColumnClasses = 'col-lg-2 col-md-4 col-sm-6 col-xs-6';
+const statusColumnClasses = 'col-lg-2 col-md-4 hidden-sm hidden-xs';
+const roleColumnClasses = 'col-lg-1 visible-lg';
+const hideableColumnClasses = 'col-lg-2 visible-lg';
+
+const HostHeader = props => (
+  <ListHeader>
+    <ColHead {...props} className={mainColumnClasses} sortField="metadata.name">
+      Name
+    </ColHead>
+    <ColHead
+      {...props}
+      className={mainColumnClasses}
+      sortField="metadata.namespace"
+    >
+      Namespace
+    </ColHead>
+    <ColHead {...props} className={statusColumnClasses}>
+      Status
+    </ColHead>
+    <ColHead {...props} className={hideableColumnClasses}>
+      Machine
+    </ColHead>
+    <ColHead {...props} className={roleColumnClasses}>
+      Role
+    </ColHead>
+    <ColHead
+      {...props}
+      className={hideableColumnClasses}
+      sortField="spec.bmc.address"
+    >
+      Management Address
+    </ColHead>
+  </ListHeader>
+);
+
+const HostRow = ({ obj: host }) => {
+  const {
+    metadata: { name, namespace, uid },
+    spec: {
+      bmc: { address },
+    },
+  } = host;
+
+  return (
+    <ResourceRow obj={host}>
+      <div className={mainColumnClasses}>
+        <ResourceLink
+          kind={BaremetalHostModel.kind}
+          name={name}
+          namespace={namespace}
+          title={uid}
+        />
+      </div>
+      <div className={mainColumnClasses}>
+        <ResourceLink
+          kind={NamespaceModel.kind}
+          name={namespace}
+          title={namespace}
+        />
+      </div>
+      <div className={statusColumnClasses}>-</div>
+      <div className={hideableColumnClasses}>-</div>
+      <div className={roleColumnClasses}>-</div>
+      <div className={hideableColumnClasses}>{address}</div>
+    </ResourceRow>
+  );
+};
+
+const HostList = props => <List {...props} Header={HostHeader} Row={HostRow} />;
+
+export class BaremetalHostsPage extends React.Component {
+  render() {
+    return (
+      <ListPage
+        {...this.props}
+        canCreate={true}
+        createButtonText="Create Host"
+        kind={BaremetalHostModel.kind}
+        ListComponent={HostList}
+      />
+    );
+  }
+}

--- a/frontend/public/metalkube/components/host/index.tsx
+++ b/frontend/public/metalkube/components/host/index.tsx
@@ -1,0 +1,2 @@
+// ./vm.ts already imported by okd-core models due to feature detection
+export * from './host';

--- a/frontend/public/metalkube/components/utils/okdutils.tsx
+++ b/frontend/public/metalkube/components/utils/okdutils.tsx
@@ -1,0 +1,6 @@
+// indirect reuse of OKD in metalkube
+
+export * from '../../../components/utils';
+export { breadcrumbsForOwnerRefs } from '../../../components/utils/breadcrumbs';
+export { ResourceSummary } from '../../../components/utils/details-page';
+export { SectionHeading } from '../../../components/utils/headings';

--- a/frontend/public/metalkube/models/host.ts
+++ b/frontend/public/metalkube/models/host.ts
@@ -1,0 +1,17 @@
+// eslint-disable-next-line no-unused-vars
+import { K8sKind } from '../../module/k8s';
+
+// TODO: reuse following from kubevirt-web-ui-components to avoid duplicity
+
+export const BaremetalHostModel: K8sKind = {
+  label: 'Bare Metal Host',
+  labelPlural: 'Bare Metal Hosts',
+  apiVersion: 'v1alpha1',
+  path: 'baremetalhosts',
+  apiGroup: 'metalkube.org',
+  plural: 'baremetalhosts',
+  abbr: 'BMH',
+  namespaced: true,
+  kind: 'BareMetalHost',
+  id: 'baremetalhost',
+};

--- a/frontend/public/metalkube/models/index.ts
+++ b/frontend/public/metalkube/models/index.ts
@@ -1,0 +1,2 @@
+// ./host.ts already imported by okd-core models due to feature detection
+export * from '../../models';

--- a/frontend/public/models/index.ts
+++ b/frontend/public/models/index.ts
@@ -792,6 +792,7 @@ export const ServiceBindingModel: K8sKind = {
 };
 
 export * from '../kubevirt/models/vm'; // needed when setting features and resource pages
+export * from '../metalkube/models/host'; // needed when setting features and resource pages
 
 export const LimitRangeModel: K8sKind = {
   label: 'Limit Range',


### PR DESCRIPTION
* Creates metalkube extension directory structure based on kubevirt extension
* Adds Hosts link to kubevirt nav extension
* Adds Metalkube flag and CRD in features
* Adds BaremetalHostModel
* Adds Basic HostsPage based on kubevirt vm listing