### PR TITLE
Added TC that add/remove disk/nic to running VM, added VM, VMI models

### DIFF
--- a/frontend/integration-tests/tests/kubevirt/models/VirtualMachineInstance.ts
+++ b/frontend/integration-tests/tests/kubevirt/models/VirtualMachineInstance.ts
@@ -1,0 +1,16 @@
+import { volumeRows } from '../../../views/kubevirt/virtualMachineInstance.view';
+import { DetailView } from './detailView';
+
+export class VirtualMachineInstance extends DetailView {
+  constructor(name: string, namespace: string) {
+    super(name, namespace, 'pods');
+  }
+
+  async getVolumes() {
+    const disks = [];
+    for (const row of await volumeRows) {
+      disks.push(await row.$$('div').first().getText());
+    }
+    return disks;
+  }
+}

--- a/frontend/integration-tests/tests/kubevirt/models/detailView.ts
+++ b/frontend/integration-tests/tests/kubevirt/models/detailView.ts
@@ -1,0 +1,44 @@
+/* eslint-disable no-unused-vars, no-undef */
+import { browser } from 'protractor';
+
+import { appHost } from '../../../protractor.conf';
+import { clickHorizontalTab } from '../../../views/horizontal-nav.view';
+import { isLoaded } from '../../../views/crud.view';
+import * as vmView from '../../../views/kubevirt/virtualMachine.view';
+import { editorContent, isLoaded as isYamlLoaded } from '../../../views/yaml.view';
+
+export class DetailView {
+  readonly name: string;
+  readonly namespace: string;
+  readonly kind: string;
+
+  constructor(name: string, namespace: string, kind: string) {
+    this.name = name;
+    this.namespace = namespace;
+    this.kind = kind;
+  }
+
+  static async getResourceTitle() {
+    return vmView.resourceTitle.getText();
+  }
+
+  async navigateToTab(tabName: string) {
+    if (!await vmView.resourceTitle.isPresent() || await vmView.resourceTitle.getText() !== this.name) {
+      await browser.get(`${appHost}/k8s/ns/${this.namespace}/${this.kind}/${this.name}`);
+      await isLoaded();
+    }
+    await clickHorizontalTab(tabName);
+  }
+
+  /**
+   * Search YAML manifest for a given string.
+   * @param     {string}    needle    String to search in YAML.
+   * @returns   {boolean}             True if found, false otherwise.
+   */
+  async searchYAML(needle: string): Promise<boolean> {
+    await this.navigateToTab(vmView.yamlTab);
+    await isYamlLoaded();
+    const yaml = await editorContent.getText();
+    return yaml.search(needle) >= 0;
+  }
+}

--- a/frontend/integration-tests/tests/kubevirt/models/virtualMachine.ts
+++ b/frontend/integration-tests/tests/kubevirt/models/virtualMachine.ts
@@ -1,0 +1,93 @@
+/* eslint-disable no-unused-vars, no-undef */
+import { browser, ExpectedConditions as until } from 'protractor';
+
+import { testName } from '../../../protractor.conf';
+import * as vmView from '../../../views/kubevirt/virtualMachine.view';
+import { confirmAction, resourceRows, isLoaded } from '../../../views/crud.view';
+import { fillInput, PAGE_LOAD_TIMEOUT, selectDropdownOption, VM_BOOTUP_TIMEOUT, VM_STOP_TIMEOUT } from '../utils';
+import { DetailView } from './detailView';
+import { VirtualMachineInstance } from './VirtualMachineInstance';
+import { detailViewVmIcon, detailViewAction, runningIcon, pendingIcon, offIcon } from '../../../views/kubevirt/vm.actions.view';
+
+export class VirtualMachine extends DetailView {
+  constructor(name: string, namespace: string) {
+    super(name, namespace, 'virtualmachines');
+  }
+
+  async navigateToVmi(vmiTab: string): Promise<VirtualMachineInstance> {
+    await this.navigateToTab(vmView.overviewTab).then(() => isLoaded());
+    await browser.wait(until.elementToBeClickable(vmView.statusLink))
+      .then(async() => await vmView.statusLink.click())
+      .then(async() => await isLoaded());
+    const vmi = new VirtualMachineInstance(await DetailView.getResourceTitle(), testName);
+    await vmi.navigateToTab(vmiTab);
+    return vmi;
+  }
+
+  async action(action: string) {
+    await this.navigateToTab(vmView.overviewTab);
+    await detailViewAction(action);
+    switch (action) {
+      case 'Start':
+        await browser.wait(until.presenceOf(detailViewVmIcon(runningIcon)), VM_BOOTUP_TIMEOUT);
+        break;
+      case 'Restart':
+        await browser.wait(until.presenceOf(detailViewVmIcon(pendingIcon)), VM_BOOTUP_TIMEOUT);
+        await browser.wait(until.presenceOf(detailViewVmIcon(runningIcon)), VM_BOOTUP_TIMEOUT);
+        break;
+      case 'Stop':
+        await browser.wait(until.presenceOf(detailViewVmIcon(offIcon)), VM_STOP_TIMEOUT);
+        break;
+      case 'Delete':
+        // wait for redirect
+        await browser.wait(until.textToBePresentInElement(vmView.resourceTitle, 'Virtual Machines'), PAGE_LOAD_TIMEOUT);
+        break;
+      default:
+        throw Error('Received unexpected action.');
+    }
+  }
+
+  async getAttachedResources(resourceTab: string): Promise<string[]> {
+    await this.navigateToTab(resourceTab);
+    const resources = [];
+    await browser.sleep(500);
+    for (const row of await resourceRows) {
+      resources.push(await row.$$('div').first().getText());
+    }
+    return resources;
+  }
+
+  async resourceExists(resourceName) {
+    return vmView.rowForName(resourceName).isPresent();
+  }
+
+  async addDisk(name: string, size: string, storageClass: string) {
+    await this.navigateToTab(vmView.disksTab);
+    await vmView.createDisk.click();
+    await fillInput(vmView.diskName, name);
+    await fillInput(vmView.diskSize, size);
+    await selectDropdownOption(vmView.diskStorageClassDropdownId, storageClass);
+    await vmView.applyBtn.click();
+  }
+
+  async removeDisk(name: string) {
+    await this.navigateToTab(vmView.disksTab);
+    await vmView.selectKebabOption(name, 'Delete');
+    await confirmAction();
+  }
+
+  async addNic(name: string, mac: string, networkAttachmentDefinition: string) {
+    await this.navigateToTab(vmView.nicsTab);
+    await vmView.createNic.click();
+    await fillInput(vmView.nicName, name);
+    await fillInput(vmView.macAddress, mac);
+    await selectDropdownOption(vmView.networkTypeDropdownId, networkAttachmentDefinition);
+    await vmView.applyBtn.click();
+  }
+
+  async removeNic(name: string) {
+    await this.navigateToTab(vmView.nicsTab);
+    await vmView.selectKebabOption(name, 'Delete');
+    await confirmAction();
+  }
+}

--- a/frontend/integration-tests/tests/kubevirt/utils.ts
+++ b/frontend/integration-tests/tests/kubevirt/utils.ts
@@ -1,6 +1,6 @@
 /* eslint-disable no-unused-vars, no-undef */
 import { execSync } from 'child_process';
-import { $, by, ElementFinder } from 'protractor';
+import { $, by, ElementFinder, browser, ExpectedConditions as until } from 'protractor';
 
 export const PAGE_LOAD_TIMEOUT = 5000;
 export const WIZARD_LOAD_TIMEOUT = 10000;
@@ -41,7 +41,8 @@ export function removeLeakedResources(leakedResources: Set<string>) {
 }
 
 export async function selectDropdownOption(dropdownId: string, option: string) {
-  await $(dropdownId).click();
+  await browser.wait(until.elementToBeClickable($(dropdownId)))
+    .then(() => $(dropdownId).click());
   await $(`${dropdownId} + ul`).element(by.linkText(option)).click();
 }
 

--- a/frontend/integration-tests/views/crud.view.ts
+++ b/frontend/integration-tests/views/crud.view.ts
@@ -13,7 +13,9 @@ export const saveChangesBtn = $('#save-changes');
 export const reloadBtn = $('#reload-object');
 export const cancelBtn = $('#cancel');
 
-export const confirmAction = () => browser.wait(until.presenceOf($('#confirm-action'))).then(() => $('#confirm-action').click());
+export const confirmAction = () => browser.wait(until.presenceOf($('#confirm-action')))
+  .then(() => $('#confirm-action').click())
+  .then(() => browser.wait(until.not(until.presenceOf($('.co-overlay')))));
 
 /**
  * Returns a promise that resolves after the loading spinner is not present.

--- a/frontend/integration-tests/views/kubevirt/virtualMachine.view.ts
+++ b/frontend/integration-tests/views/kubevirt/virtualMachine.view.ts
@@ -1,0 +1,41 @@
+/* eslint-disable no-unused-vars, no-undef */
+import { $, browser, ExpectedConditions as until } from 'protractor';
+import { resourceRows } from '../crud.view';
+
+export const resourceTitle = $('#resource-title');
+
+export const overviewTab = 'Overview';
+export const yamlTab = 'YAML';
+export const consolesTab = 'Consoles';
+export const EventsTab = 'Events';
+export const disksTab = 'Disks';
+export const nicsTab = 'Network Interfaces';
+
+export const createNic = $('#create-nic-btn');
+export const createDisk = $('#create-disk-btn');
+
+export const nicName = $('#nic-name');
+export const macAddress = $('#mac-address');
+export const networkTypeDropdownId = '#network-type';
+
+export const diskName = $('#disk-name');
+export const diskSize = $('#disk-size');
+export const diskStorageClassDropdownId = '#disk-storage-class';
+
+export const cancelBtn = $('button.kubevirt-cancel-accept-buttons.btn-default');
+export const applyBtn = $('button.kubevirt-cancel-accept-buttons.btn-primary');
+
+export const statusLink = $('a.kubevirt-vm-status__link');
+export const rowForName = (name: string) => resourceRows
+  .filter((row) => row.$$('div').first().getText()
+    .then(text => text === name)).first();
+export const kebabForName = (name: string) => rowForName(name).$('button.co-kebab__button');
+export const selectKebabOption = async(name: string, option: string) => {
+  await browser.wait(until.presenceOf(kebabForName(name)));
+  // open kebab dropdown
+  await kebabForName(name).click();
+  // select given option from opened dropdown
+  await rowForName(name).$('.co-kebab__dropdown').$$('a')
+    .filter(link => link.getText()
+      .then(text => text.startsWith(option))).first().click();
+};

--- a/frontend/integration-tests/views/kubevirt/virtualMachineInstance.view.ts
+++ b/frontend/integration-tests/views/kubevirt/virtualMachineInstance.view.ts
@@ -1,0 +1,6 @@
+/* eslint-disable no-unused-vars, no-undef */
+import { $$ } from 'protractor';
+
+export const volumeRowsTable = $$('.co-m-pane__body').filter((table) => table.$('.co-section-heading').getText().then(text => text === 'Pod Volumes')).first();
+export const volumeRows = volumeRowsTable.$('.co-m-table-grid__body').$$('.row');
+export const volumeRowByName = (name: string) => volumeRows.filter((row) => row.$('div').getText().then(text => text === name)).first();


### PR DESCRIPTION
Implemented following test cases:
https://polarion.engineering.redhat.com/polarion/redirect/project/CNV/workitem?id=CNV-1502
https://polarion.engineering.redhat.com/polarion/redirect/project/CNV/workitem?id=CNV-1501

Added models for VM and VM with required functionality to add/remove resources and navigate between tabs.

There is a caveat though, which is checking the YAML manifest - I haven't found a way to obtain the whole manifest file from UI. From the yaml tab page, it is only possible to get content that is visible, as it is dynamically generated when scrolling.

For checking disk on VMI instance, I have used the overview page and for checking NIC I have used the yaml page as nics are located at the top and therefore visible.

But other ideas are welcome, maybe it would be better to use oc command to query the yaml.