### PR TITLE
Create VM templates list page via resource pages

### DIFF
--- a/frontend/public/components/app.jsx
+++ b/frontend/public/components/app.jsx
@@ -26,8 +26,6 @@ import k8sActions, { types } from '../module/k8s/k8s-actions';
 import '../vendor.scss';
 import '../style.scss';
 
-import { VirtualMachineTemplatesPage } from '../kubevirt/components/vm-template';
-
 //PF4 Imports
 import {
   Page,
@@ -236,9 +234,6 @@ class App extends React.PureComponent {
 
                   <LazyRoute path="/k8s/all-namespaces/import" exact loader={() => import('./import-yaml' /* webpackChunkName: "import-yaml" */).then(m => NamespaceFromURL(m.ImportYamlPage))} />
                   <LazyRoute path="/k8s/ns/:ns/import/" exact loader={() => import('./import-yaml' /* webpackChunkName: "import-yaml" */).then(m => NamespaceFromURL(m.ImportYamlPage))} />
-
-                  <Route path="/k8s/ns/:ns/vmtemplates" exact component={VirtualMachineTemplatesPage} />
-                  <Route path="/k8s/all-namespaces/vmtemplates" exact component={VirtualMachineTemplatesPage} />
 
                   {
                     // These pages are temporarily disabled. We need to update the safe resources list.

--- a/frontend/public/components/resource-pages.ts
+++ b/frontend/public/components/resource-pages.ts
@@ -169,6 +169,7 @@ export const resourceListPages = ImmutableMap<GroupVersionKind | string, () => P
   .set(referenceForModel(StorageClassModel), () => import('./storage-class' /* webpackChunkName: "storage-class" */).then(m => m.StorageClassPage))
   .set(referenceForModel(CustomResourceDefinitionModel), () => import('./custom-resource-definition' /* webpackChunkName: "custom-resource-definition" */).then(m => m.CustomResourceDefinitionsPage))
   .set(referenceForModel(VirtualMachineModel), () => import('../kubevirt/components/vm' /* webpackChunkName: "virtual-machines" */).then(m => m.VirtualMachinesPage))
+  .set(referenceForModel(VmTemplateModel), () => import('../kubevirt/components/vm-template' /* webpackChunkName: "vm-templates" */).then(m => m.VirtualMachineTemplatesPage))
   .set(referenceForModel(BaremetalHostModel), () => import('../metalkube/components/host/host' /* webpackChunkName: "baremetal-hosts" */).then(m => m.BaremetalHostsPage))
   .set(referenceForModel(ClusterServiceVersionModel), () => import('./operator-lifecycle-manager/clusterserviceversion' /* webpackChunkName: "clusterserviceversion" */).then(m => m.ClusterServiceVersionsPage))
   .set(referenceForModel(PackageManifestModel), () => import('./operator-lifecycle-manager/package-manifest' /* webpackChunkName: "package-manifest" */).then(m => m.PackageManifestsPage))

--- a/frontend/public/kubevirt/models/vm.ts
+++ b/frontend/public/kubevirt/models/vm.ts
@@ -75,7 +75,7 @@ export const VmTemplateModel: K8sKind = {
   apiVersion: 'v1',
   path: 'templates',
   apiGroup: 'template.openshift.io',
-  plural: 'templates',
+  plural: 'vmtemplates',
   namespaced: true,
   abbr: 'VMT',
   kind: 'Template',


### PR DESCRIPTION
This PR addresses a bug [1] wherein the VM templates page isn't disabled and doesn't display the create project start guide when the user has no projects/namespaces.

[1] https://bugzilla.redhat.com/show_bug.cgi?id=1677243