### PR TITLE
Filter NAD by namespace when creating new nic raw

### DIFF
--- a/frontend/public/kubevirt/components/nic.jsx
+++ b/frontend/public/kubevirt/components/nic.jsx
@@ -85,8 +85,9 @@ const NIC_TYPE_VM = 'nic-type-vm';
 const NIC_TYPE_CREATE = 'nic-type-create';
 
 export const NicRow = (onChange, onAccept, onCancel) => ({obj: nic}) => {
+  const namespace = (nic.vm && nic.vm.metadata.namespace) || (nic.vmTemplate && nic.vmTemplate.metadata.namespace);
   const networks = {
-    resource: getResource(NetworkAttachmentDefinitionModel),
+    resource: getResource(NetworkAttachmentDefinitionModel, {namespace}),
   };
   switch (nic.nicType) {
     case NIC_TYPE_VM:
@@ -153,6 +154,7 @@ export class Nic extends React.Component {
           value: getVmNicModel(this.props.vm),
         },
         vm: this.props.vm,
+        vmTemplate: this.props.vmTemplate,
       },
     });
   }

--- a/frontend/public/kubevirt/components/nic.jsx
+++ b/frontend/public/kubevirt/components/nic.jsx
@@ -7,7 +7,7 @@ import { Kebab, LoadingInline } from './utils/okdutils';
 import { List, ColHead, ListHeader, ResourceRow } from './factory/okdfactory';
 import { DASHES, BUS_VIRTIO, NIC } from './utils/constants';
 import { deleteDeviceModal } from './modals/delete-device-modal';
-import { getNetworks, CreateNicRow, getAddNicPatch, POD_NETWORK, settingsValue, getResource, addPrefixToPatch, getInterfaceBinding } from 'kubevirt-web-ui-components';
+import { getNetworks, CreateNicRow, getAddNicPatch, POD_NETWORK, settingsValue, getNamespace, getResource, addPrefixToPatch, getInterfaceBinding } from 'kubevirt-web-ui-components';
 import { NetworkAttachmentDefinitionModel, VirtualMachineModel, VmTemplateModel } from '../models';
 import { WithResources } from './utils/withResources';
 import { k8sPatch } from '../module/okdk8s';
@@ -85,7 +85,7 @@ const NIC_TYPE_VM = 'nic-type-vm';
 const NIC_TYPE_CREATE = 'nic-type-create';
 
 export const NicRow = (onChange, onAccept, onCancel) => ({obj: nic}) => {
-  const namespace = (nic.vm && nic.vm.metadata.namespace) || (nic.vmTemplate && nic.vmTemplate.metadata.namespace);
+  const namespace = getNamespace(nic.vm) || getNamespace(nic.vmTemplate);
   const networks = {
     resource: getResource(NetworkAttachmentDefinitionModel, {namespace}),
   };

--- a/frontend/public/kubevirt/components/nic.jsx
+++ b/frontend/public/kubevirt/components/nic.jsx
@@ -95,7 +95,7 @@ const NIC_TYPE_VM = 'nic-type-vm';
 const NIC_TYPE_CREATE = 'nic-type-create';
 
 export const NicRow = (onChange, onAccept, onCancel) => ({obj: nic}) => {
-  const namespace = getNamespace(nic.vm) || getNamespace(nic.vmTemplate);
+  const namespace = getNamespace(nic.vm || nic.vmTemplate);
   const networks = {
     resource: getResource(NetworkAttachmentDefinitionModel, {namespace}),
   };

--- a/frontend/public/kubevirt/components/nic.jsx
+++ b/frontend/public/kubevirt/components/nic.jsx
@@ -7,7 +7,17 @@ import { Kebab, LoadingInline } from './utils/okdutils';
 import { List, ColHead, ListHeader, ResourceRow } from './factory/okdfactory';
 import { DASHES, BUS_VIRTIO, NIC } from './utils/constants';
 import { deleteDeviceModal } from './modals/delete-device-modal';
-import { getNetworks, CreateNicRow, getAddNicPatch, POD_NETWORK, settingsValue, getNamespace, getResource, addPrefixToPatch, getInterfaceBinding } from 'kubevirt-web-ui-components';
+import {
+  getNetworks,
+  CreateNicRow,
+  getAddNicPatch,
+  POD_NETWORK,
+  settingsValue,
+  getNamespace,
+  getResource,
+  addPrefixToPatch,
+  getInterfaceBinding,
+} from 'kubevirt-web-ui-components';
 import { NetworkAttachmentDefinitionModel, VirtualMachineModel, VmTemplateModel } from '../models';
 import { WithResources } from './utils/withResources';
 import { k8sPatch } from '../module/okdk8s';


### PR DESCRIPTION
When getting network resource for a nic we want to filter it by namespace.

Currently we filter by namespace on the web-ui-component side [1] but we may want to remove this filter for cases that do not have a namespace.

BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1687917

[1] https://github.com/kubevirt/web-ui-components/pull/316