### PR TITLE
Introduce LazyRenderer component

### DIFF
--- a/frontend/public/kubevirt/components/cluster/cluster-overview.jsx
+++ b/frontend/public/kubevirt/components/cluster/cluster-overview.jsx
@@ -22,7 +22,8 @@ import { coFetch, coFetchJSON } from '../../../co-fetch';
 
 import { EventStream } from '../../../components/events';
 import { EventsInnerOverview } from './events-inner-overview';
-import { LoadingInline } from '../utils/okdutils';
+import { LoadingInline} from '../utils/okdutils';
+import { LazyRenderer } from '../utils/lazyRenderer';
 
 const CONSUMERS_CPU_QUERY = 'sort(topk(5, sum by (pod_name)(container_cpu_usage_seconds_total{pod_name!=""})))';
 const CONSUMERS_MEMORY_QUERY = 'sort(topk(5, sum by (pod_name)(container_memory_usage_bytes{pod_name!=""})))';
@@ -249,9 +250,11 @@ export class ClusterOverview extends React.Component {
 
     return (
       <WithResources resourceMap={resourceMap} resourceToProps={inventoryResourceMapToProps}>
-        <ClusterOverviewContext.Provider>
-          <KubevirtClusterOverview />
-        </ClusterOverviewContext.Provider>
+        <LazyRenderer>
+          <ClusterOverviewContext.Provider>
+            <KubevirtClusterOverview />
+          </ClusterOverviewContext.Provider>
+        </LazyRenderer>
       </WithResources>
     );
   }

--- a/frontend/public/kubevirt/components/utils/lazyRenderer.jsx
+++ b/frontend/public/kubevirt/components/utils/lazyRenderer.jsx
@@ -1,0 +1,45 @@
+import React from 'react';
+import * as _ from 'lodash-es';
+import { inject } from '../../../components/utils';
+
+const DEFAULT_THROTTLE_DELAY = 250; // in ms
+
+/**
+ * Avoids eager re-rendering for frequent redux store changes.
+ *
+ * Assumption: re-render requests are frequent, so skipping a few of them
+ * has no impact on rendered information from user's perspective.
+ *
+ * If that assumption is not met, the use of this component is not recommended.
+ */
+export class LazyRenderer extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      isRenderingEnabled: false,
+    };
+    this.enableRendering = _.throttle(() => {
+      this.setState({
+        isRenderingEnabled: true,
+      });
+    }, DEFAULT_THROTTLE_DELAY);
+  }
+
+  shouldComponentUpdate(nextProps, nextState) {
+    this.enableRendering();
+
+    if (nextState.isRenderingEnabled) {
+      // will cause additional shouldComponentUpdate() call
+      this.setState({ isRenderingEnabled: false });
+    }
+    return nextState.isRenderingEnabled;
+  }
+
+  componentWillUnmount() {
+    this.enableRendering.cancel();
+  }
+
+  render() {
+    return inject(this.props.children, this.props);
+  }
+}


### PR DESCRIPTION
Avoids eager re-rendering for frequent redux store changes.

Assumption: re-render requests are frequent, so skipping a few of them
has no impact on rendered information from user's perspective.

If that assumption is not met, the use of this component is not recommended.
