### PR TITLE
Fix undefined namespace when NIC called from VmTemplateDetails

### DIFF
--- a/frontend/public/kubevirt/components/nic.jsx
+++ b/frontend/public/kubevirt/components/nic.jsx
@@ -95,7 +95,7 @@ const NIC_TYPE_VM = 'nic-type-vm';
 const NIC_TYPE_CREATE = 'nic-type-create';
 
 export const NicRow = (onChange, onAccept, onCancel) => ({obj: nic}) => {
-  // NOTE: nic.vm is a required prop, it is always defined even if
+  // NOTE:
   // getNamespace(nic.vmTemplate || nic.vm) is not equal to
   // getNamespace(nic.vm || nic.vmTemplate)
   // nic.vm is allways defined, while nic.vmTemplate is only defined when called from

--- a/frontend/public/kubevirt/components/nic.jsx
+++ b/frontend/public/kubevirt/components/nic.jsx
@@ -95,7 +95,13 @@ const NIC_TYPE_VM = 'nic-type-vm';
 const NIC_TYPE_CREATE = 'nic-type-create';
 
 export const NicRow = (onChange, onAccept, onCancel) => ({obj: nic}) => {
-  const namespace = getNamespace(nic.vm || nic.vmTemplate);
+  // NOTE: nic.vm is a required prop, it is always defined even if
+  // NicRaw is called from a template page where vm is not completely defined,
+  // in that case:
+  //   getNamespace(nic.vm || nic.vmTemplate) will be undefined.
+  //   while:
+  //   getNamespace(nic.vm) || getNamespace(nic.vmTemplate) will be the namespace of vmTemplate.
+  const namespace = getNamespace(nic.vm) || getNamespace(nic.vmTemplate);
   const networks = {
     resource: getResource(NetworkAttachmentDefinitionModel, {namespace}),
   };

--- a/frontend/public/kubevirt/components/nic.jsx
+++ b/frontend/public/kubevirt/components/nic.jsx
@@ -254,7 +254,7 @@ export class Nic extends React.Component {
 }
 
 Nic.propTypes = {
-  vm: PropTypes.object.isRequired,
+  vm: PropTypes.object.isRequired, // vm may be a template vm.
   vmTemplate: PropTypes.object, // the template of the vm
   patchPrefix: PropTypes.string, // path to the vm in the template
 };

--- a/frontend/public/kubevirt/components/nic.jsx
+++ b/frontend/public/kubevirt/components/nic.jsx
@@ -96,12 +96,11 @@ const NIC_TYPE_CREATE = 'nic-type-create';
 
 export const NicRow = (onChange, onAccept, onCancel) => ({obj: nic}) => {
   // NOTE: nic.vm is a required prop, it is always defined even if
-  // NicRaw is called from a template page where vm is not completely defined,
-  // in that case:
-  //   getNamespace(nic.vm || nic.vmTemplate) will be undefined.
-  //   while:
-  //   getNamespace(nic.vm) || getNamespace(nic.vmTemplate) will be the namespace of vmTemplate.
-  const namespace = getNamespace(nic.vm) || getNamespace(nic.vmTemplate);
+  // getNamespace(nic.vmTemplate || nic.vm) is not equal to
+  // getNamespace(nic.vm || nic.vmTemplate)
+  // nic.vm is allways defined, while nic.vmTemplate is only defined when called from
+  // VmTemplateDetails.
+  const namespace = getNamespace(nic.vmTemplate || nic.vm);
   const networks = {
     resource: getResource(NetworkAttachmentDefinitionModel, {namespace}),
   };

--- a/frontend/public/kubevirt/components/nic.jsx
+++ b/frontend/public/kubevirt/components/nic.jsx
@@ -95,12 +95,7 @@ const NIC_TYPE_VM = 'nic-type-vm';
 const NIC_TYPE_CREATE = 'nic-type-create';
 
 export const NicRow = (onChange, onAccept, onCancel) => ({obj: nic}) => {
-  // NOTE:
-  // getNamespace(nic.vmTemplate || nic.vm) is not equal to
-  // getNamespace(nic.vm || nic.vmTemplate)
-  // nic.vm is allways defined, while nic.vmTemplate is only defined when called from
-  // VmTemplateDetails.
-  const namespace = getNamespace(nic.vmTemplate || nic.vm);
+  const namespace = getNamespace(nic.vmTemplate || nic.vm); // order matters
   const networks = {
     resource: getResource(NetworkAttachmentDefinitionModel, {namespace}),
   };

--- a/frontend/public/kubevirt/components/nic.jsx
+++ b/frontend/public/kubevirt/components/nic.jsx
@@ -254,7 +254,7 @@ export class Nic extends React.Component {
 }
 
 Nic.propTypes = {
-  vm: PropTypes.object.isRequired, // vm may be a template vm.
+  vm: PropTypes.object.isRequired, // vm may be a template vm
   vmTemplate: PropTypes.object, // the template of the vm
   patchPrefix: PropTypes.string, // path to the vm in the template
 };


### PR DESCRIPTION
In #265 I made a mistake resulting in `undefined` `namespace` when calling `NIC` from `VmTemplateDetails` page.

In:
https://github.com/kubevirt/web-ui/blob/master/frontend/public/kubevirt/components/vm-template/vm-template-detail.jsx#L44
`vm` may be defined ( e.g. not `undefined` ) but missing a `namespace` label.

`getNamespace(nic.vm || nic.vmTemplate)` may result in undefined, while the expected result is the template namespace.

This PR use ~err to the side of safety by using~ the ~longer~ phrase:
~`getNamespace(nic.vm) || getNamespace(nic.vmTemplate)`~ getNamespace(nic.vmTemplate || nic.vm)

EDIT:
`getNamespace(nic.vmTemplate || nic.vm)` is OK because `vmTemplate` is only defined when calling from the template details page, and undefined when calling from the `vm` page.
