### PR TITLE
Use diferent nameing schema for status group than single status

### DIFF
--- a/frontend/public/kubevirt/components/vm/vm.jsx
+++ b/frontend/public/kubevirt/components/vm/vm.jsx
@@ -3,8 +3,8 @@ import { connect } from 'react-redux';
 import {
   VmStatus,
   getSimpleVmStatus,
-  VM_STATUS_ALL,
-  VM_STATUS_TO_TEXT,
+  VM_SIMPLE_STATUS_ALL,
+  VM_SIMPLE_STATUS_TO_TEXT,
   CDI_KUBEVIRT_IO,
   getResource,
 } from 'kubevirt-web-ui-components';
@@ -88,9 +88,9 @@ const mapDispatchToProps = () => ({
 
 const filters = [{
   type: 'vm-status',
-  selected: VM_STATUS_ALL,
+  selected: VM_SIMPLE_STATUS_ALL,
   reducer: getSimpleVmStatus,
-  items: VM_STATUS_ALL.map(status => ({ id: status, title: VM_STATUS_TO_TEXT[status] }) ),
+  items: VM_SIMPLE_STATUS_ALL.map(status => ({ id: status, title: VM_SIMPLE_STATUS_TO_TEXT[status] }) ),
 }];
 
 export const VirtualMachinesPage = connect(


### PR DESCRIPTION
Curently we name:
VM_STATUS_ALL - an array of VM_STATUS_[ status ] statuses
VM_STATUS_TO_TEXT  - a map of arrays of VM_STATUS_[ status ] statuses to strings
in a confusing way.

Ref: 
https://github.com/kubevirt/web-ui-components/pull/340
https://github.com/kubevirt/web-ui-components/pull/340#issuecomment-481701736