### PR TITLE
Provide machine and nodes resources to BaremetalHostStatus

### DIFF
--- a/frontend/public/metalkube/components/host/host.tsx
+++ b/frontend/public/metalkube/components/host/host.tsx
@@ -78,6 +78,9 @@ const HostRow = ({ obj: host }) => {
     machine: {
       resource: machineResource,
     },
+    nodes: {
+      resource: getResource(NodeModel, { namespaced: false }),
+    },
   };
 
   const hostResources = machineName
@@ -95,7 +98,9 @@ const HostRow = ({ obj: host }) => {
         />
       </div>
       <div className={statusColumnClasses}>
-        <BaremetalHostStatus host={host} />
+        <WithResources resourceMap={machineName ? hostResourceMap : {}}>
+          <BaremetalHostStatus host={host} />
+        </WithResources>
       </div>
       <div className={machineColumnClasses}>
         <MachineCell host={host} />


### PR DESCRIPTION
This allows the host status to be based on related machine/node
status

Depends on https://github.com/kubevirt/web-ui-components/pull/363