### PR TITLE
Metalkube renamed to Metal3

### DIFF
--- a/frontend/public/metalkube/models/host.ts
+++ b/frontend/public/metalkube/models/host.ts
@@ -8,7 +8,7 @@ export const BaremetalHostModel: K8sKind = {
   labelPlural: 'Bare Metal Hosts',
   apiVersion: 'v1alpha1',
   path: 'baremetalhosts',
-  apiGroup: 'metalkube.org',
+  apiGroup: 'metal3.io',
   plural: 'baremetalhosts',
   abbr: 'BMH',
   namespaced: true,


### PR DESCRIPTION
* update apiGroup in BaremetalHostModel to match the new name

The metalkube project rename causes the baremetal hosts menu section not getting displayed.