### PR TITLE
Revert "Metalkube renamed to Metal3"

### DIFF
--- a/frontend/public/metalkube/models/host.ts
+++ b/frontend/public/metalkube/models/host.ts
@@ -8,7 +8,7 @@ export const BaremetalHostModel: K8sKind = {
   labelPlural: 'Bare Metal Hosts',
   apiVersion: 'v1alpha1',
   path: 'baremetalhosts',
-  apiGroup: 'metal3.io',
+  apiGroup: 'metalkube.org',
   plural: 'baremetalhosts',
   abbr: 'BMH',
   namespaced: true,


### PR DESCRIPTION
Reverts kubevirt/web-ui#336

The backport is not needed as openshift-metal3/dev-scripts ensures that baremetal operator uses old metalkube.org api org (https://github.com/openshift-metal3/dev-scripts/blob/master/08_deploy_bmo.sh#L15)