### PR TITLE
Add Node maintenance test cases

### DIFF
--- a/frontend/integration-tests/protractor.conf.ts
+++ b/frontend/integration-tests/protractor.conf.ts
@@ -188,6 +188,7 @@ export const config: Config = {
       'tests/kubevirt/clone.vm.scenario.ts',
       'tests/kubevirt/vm.yaml.scenario.ts',
       'tests/kubevirt/vm.overview.scenario.ts',
+      'tests/kubevirt/node.maintenance.scenario.ts',
     ],
     kubevirtWindows: [
       'tests/kubevirt/kubevirt.login.scenario.ts',

--- a/frontend/integration-tests/tests/kubevirt/clone.vm.scenario.ts
+++ b/frontend/integration-tests/tests/kubevirt/clone.vm.scenario.ts
@@ -1,11 +1,11 @@
 /* eslint-disable no-undef, max-nested-callbacks */
 import { execSync } from 'child_process';
-import { $, $$, browser, ExpectedConditions as until } from 'protractor';
+import { $, browser, ExpectedConditions as until } from 'protractor';
 import * as _ from 'lodash';
 
 // eslint-disable-next-line no-unused-vars
-import { removeLeakedResources, waitForCount, searchYAML, searchJSON, getResourceJSON,
-  CLONE_VM_TIMEOUT, VM_BOOTUP_TIMEOUT, PAGE_LOAD_TIMEOUT, VM_STOP_TIMEOUT } from './utils';
+import { removeLeakedResources, waitForCount, searchYAML, searchJSON, getResourceJSON } from './utils/utils';
+import { CLONE_VM_TIMEOUT, VM_BOOTUP_TIMEOUT, PAGE_LOAD_TIMEOUT, VM_STOP_TIMEOUT } from './utils/consts';
 import { appHost, testName } from '../../protractor.conf';
 import { filterForName, isLoaded, resourceRowsPresent, resourceRows } from '../../views/crud.view';
 import { basicVmConfig, networkInterface, testNad, getVmManifest, hddDisk, cloudInitCustomScriptConfig, emptyStr } from './mocks';
@@ -144,7 +144,7 @@ describe('Test clone VM.', () => {
       leakedResources.add(JSON.stringify({name: clonedVm.name, namespace: clonedVm.namespace, kind: 'vm'}));
       await clonedVm.navigateToTab(nicsTab);
 
-      await browser.wait(until.and(waitForCount($$('.co-resource-list__item'), 2)), PAGE_LOAD_TIMEOUT);
+      await browser.wait(until.and(waitForCount(resourceRows, 2)), PAGE_LOAD_TIMEOUT);
       // TODO: Add classes/ids to collumn attributes so that divs can be easily selected
       const mac = await resourceRows.first().$('div:nth-child(5)').getText();
       expect(mac === emptyStr).toBe(true, 'MAC address should be cleared');

--- a/frontend/integration-tests/tests/kubevirt/kubevirt.login.scenario.ts
+++ b/frontend/integration-tests/tests/kubevirt/kubevirt.login.scenario.ts
@@ -1,6 +1,6 @@
 import { browser } from 'protractor';
 import { appHost } from '../../protractor.conf';
-import { logIn } from '../kubevirt/utils';
+import { logIn } from './utils/utils';
 
 describe('Authentication', () => {
   it('Logs in.', async() => {

--- a/frontend/integration-tests/tests/kubevirt/mocks.ts
+++ b/frontend/integration-tests/tests/kubevirt/mocks.ts
@@ -289,6 +289,33 @@ export const cloudInitCustomScriptConfig = {
   customScript: basicVmConfig.cloudInitScript,
 };
 
+export const examplePod = ({name, namespace, nodeSelector}) => {
+  return {
+    apiVersion: 'v1',
+    kind: 'Pod',
+    metadata: {
+      name,
+      labels: {
+        app: 'hello-openshift',
+      },
+      namespace,
+    },
+    spec: {
+      containers: [
+        {
+          name: 'hello-openshift',
+          image: 'openshift/hello-openshift',
+          ports: [
+            {
+              containerPort: 8080,
+            },
+          ],
+        },
+      ],
+      nodeSelector,
+    },
+  };
+};
 
 export const customVMWithNicDisk = `
 apiVersion: kubevirt.io/v1alpha3

--- a/frontend/integration-tests/tests/kubevirt/models/detailView.ts
+++ b/frontend/integration-tests/tests/kubevirt/models/detailView.ts
@@ -3,8 +3,7 @@ import { browser } from 'protractor';
 
 import { appHost } from '../../../protractor.conf';
 import { clickHorizontalTab } from '../../../views/horizontal-nav.view';
-import { isLoaded } from '../../../views/crud.view';
-import * as vmView from '../../../views/kubevirt/virtualMachine.view';
+import { isLoaded, resourceTitle } from '../../../views/crud.view';
 
 export class DetailView {
   readonly name: string;
@@ -18,11 +17,11 @@ export class DetailView {
   }
 
   static async getResourceTitle() {
-    return vmView.resourceTitle.getText();
+    return resourceTitle.getText();
   }
 
   async navigateToTab(tabName: string) {
-    if (!await vmView.resourceTitle.isPresent() || await vmView.resourceTitle.getText() !== this.name) {
+    if (!await resourceTitle.isPresent() || await resourceTitle.getText() !== this.name) {
       await browser.get(`${appHost}/k8s/ns/${this.namespace}/${this.kind}/${this.name}`);
       await isLoaded();
     }

--- a/frontend/integration-tests/tests/kubevirt/models/pod.ts
+++ b/frontend/integration-tests/tests/kubevirt/models/pod.ts
@@ -1,0 +1,40 @@
+/* eslint-disable no-unused-vars, no-undef */
+import { browser, ExpectedConditions as until } from 'protractor';
+
+import * as vmView from '../../../views/kubevirt/virtualMachine.view';
+import { DetailView } from './detailView';
+import { resourceTitle, resourceRows, filterForName } from '../../../views/crud.view';
+import { PAGE_LOAD_TIMEOUT, WAIT_TIMEOUT_ERROR, POD_TERMINATION_TIMEOUT } from '../utils/consts';
+import { waitForCount } from '../utils/utils';
+import { detailViewAction } from '../../../views/kubevirt/vm.actions.view';
+import { statusIcon } from '../../../views/kubevirt/pod.view';
+
+export default class Pod extends DetailView {
+  constructor(name: string, namespace: string) {
+    super(name, namespace, 'pods');
+  }
+
+  async action(action: string) {
+    await this.navigateToTab(vmView.overviewTab);
+    const confirmDialog = true;
+
+    await detailViewAction(action, confirmDialog);
+
+    switch (action) {
+      case 'Delete':
+        await browser.wait(until.textToBePresentInElement(resourceTitle, 'Pods'), PAGE_LOAD_TIMEOUT);
+        await filterForName(this.name);
+        await browser.wait(until.and(waitForCount(resourceRows, 0)), POD_TERMINATION_TIMEOUT);
+        break;
+      default:
+        throw Error('Received unexpected action.');
+    }
+  }
+
+  async waitForStatusIcon(status: string, timeout: number) {
+    await this.navigateToTab(vmView.overviewTab);
+    await browser.wait(until.presenceOf(statusIcon(status)), timeout).catch(() => {
+      throw new Error(WAIT_TIMEOUT_ERROR);
+    });
+  }
+}

--- a/frontend/integration-tests/tests/kubevirt/models/virtualMachine.ts
+++ b/frontend/integration-tests/tests/kubevirt/models/virtualMachine.ts
@@ -4,8 +4,9 @@ import { browser, ExpectedConditions as until } from 'protractor';
 import { testName } from '../../../protractor.conf';
 import * as vmView from '../../../views/kubevirt/virtualMachine.view';
 import { nameInput } from '../../../views/kubevirt/wizard.view';
-import { confirmAction, resourceRows, isLoaded } from '../../../views/crud.view';
-import { fillInput, PAGE_LOAD_TIMEOUT, selectDropdownOption, VM_BOOTUP_TIMEOUT, VM_STOP_TIMEOUT, VM_ACTIONS_TIMEOUT } from '../utils';
+import { confirmAction, resourceRows, resourceTitle, isLoaded } from '../../../views/crud.view';
+import { fillInput, selectDropdownOption } from '../utils/utils';
+import { PAGE_LOAD_TIMEOUT, VM_BOOTUP_TIMEOUT, VM_STOP_TIMEOUT, VM_ACTIONS_TIMEOUT } from '../utils/consts';
 import { DetailView } from './detailView';
 import { VirtualMachineInstance } from './virtualMachineInstance';
 import { detailViewAction } from '../../../views/kubevirt/vm.actions.view';
@@ -59,7 +60,7 @@ export class VirtualMachine extends DetailView {
           break;
         case 'Delete':
           // wait for redirect
-          await browser.wait(until.textToBePresentInElement(vmView.resourceTitle, 'Virtual Machines'), PAGE_LOAD_TIMEOUT);
+          await browser.wait(until.textToBePresentInElement(resourceTitle, 'Virtual Machines'), PAGE_LOAD_TIMEOUT);
           break;
         default:
           throw Error('Received unexpected action.');
@@ -133,5 +134,4 @@ export class VirtualMachine extends DetailView {
     await browser.wait(until.presenceOf(vmView.rdpPort), PAGE_LOAD_TIMEOUT);
     return vmView.rdpPort.getText();
   }
-
 }

--- a/frontend/integration-tests/tests/kubevirt/models/wizard.ts
+++ b/frontend/integration-tests/tests/kubevirt/models/wizard.ts
@@ -2,7 +2,8 @@
 import { $, browser, ExpectedConditions as until } from 'protractor';
 
 import { createItemButton, isLoaded} from '../../../views/crud.view';
-import { fillInput, PAGE_LOAD_TIMEOUT, selectDropdownOption, tickCheckbox } from '../utils';
+import { fillInput, selectDropdownOption, tickCheckbox } from '../utils/utils';
+import { PAGE_LOAD_TIMEOUT } from '../utils/consts';
 import * as wizardView from '../../../views/kubevirt/wizard.view';
 
 export default class Wizard {

--- a/frontend/integration-tests/tests/kubevirt/node.maintenance.scenario.ts
+++ b/frontend/integration-tests/tests/kubevirt/node.maintenance.scenario.ts
@@ -1,0 +1,97 @@
+/* eslint-disable no-undef */
+import { browser, ExpectedConditions as until } from 'protractor';
+
+// eslint-disable-next-line no-unused-vars
+import { waitForCount, removeLeakedResources, createResource, deleteResource, addLeakableResource, removeLeakableResource, waitForStringInElement } from './utils/utils';
+import { POD_CREATE_DELETE_TIMEOUT, POD_CREATION_TIMEOUT, WAIT_TIMEOUT_ERROR, POD_TERMINATION_TIMEOUT, NODE_MAINTENANCE_STATUS, NODE_STOP_MAINTENANCE_TIMEOUT, NODE_READY_STATUS, PAGE_LOAD_TIMEOUT } from './utils/consts';
+import { examplePod } from './mocks';
+import { appHost, testName } from '../../protractor.conf';
+import { isLoaded, filterForName, resourceRows, resourceTitle } from '../../views/crud.view';
+import { listViewMaintenanceStatusForNode, listViewReadyStatusForNode } from '../../views/kubevirt/node.view';
+import { overviewTab } from '../../views/kubevirt/virtualMachine.view';
+import { detailViewAction } from '../../views/kubevirt/vm.actions.view';
+import Pod from './models/pod';
+import * as podView from '../../views/kubevirt/pod.view';
+
+
+describe('Test Node Maintenance Mode', () => {
+  const leakedResources = new Set<string>();
+  const podName = `maintenance-${testName}`;
+  const pod = new Pod(podName, testName);
+  let computeNodeName = '';
+  let computeNodeHostname = '';
+  let computeNodeURL = '';
+  const podResourceOpts = {name: podName, namespace: testName, nodeSelector: {}};
+  const podResource = examplePod(podResourceOpts);
+
+  beforeAll(async() => {
+    // Create an example hello-world pod
+    createResource(podResource);
+    addLeakableResource(leakedResources, podResource);
+
+    await pod.navigateToTab(overviewTab);
+    await pod.waitForStatusIcon(podView.statusIcons.running, POD_CREATION_TIMEOUT);
+
+    // store hostname of the compute node
+    computeNodeHostname = (await podView.nodeLink.getText()).split('.')[0];
+
+    await podView.nodeLink.click();
+    await isLoaded();
+    // store name and url of the compute node
+    computeNodeName = await resourceTitle.getText();
+    computeNodeURL = await browser.getCurrentUrl();
+  });
+
+  beforeEach(async() => {
+    await browser.get(computeNodeURL);
+    await isLoaded;
+    await detailViewAction('Start Maintenance', true);
+  });
+
+  afterEach(async() => {
+    await browser.get(computeNodeURL);
+    await isLoaded;
+    await detailViewAction('Stop Maintenance', false);
+
+    await browser.get(`${appHost}/k8s/cluster/nodes`);
+    await isLoaded();
+
+    await browser.wait(until.presenceOf(listViewReadyStatusForNode(computeNodeName)))
+      .then(() => browser.wait(waitForStringInElement(listViewReadyStatusForNode(computeNodeName), NODE_READY_STATUS), NODE_STOP_MAINTENANCE_TIMEOUT));
+
+    removeLeakedResources(leakedResources);
+  });
+
+  it('Terminates running pod on maintenance node', async() => {
+    await browser.get(`${appHost}/k8s/ns/${testName}/pods`);
+    await isLoaded();
+
+    await filterForName(podName);
+    await browser.wait(until.and(waitForCount(resourceRows, 0)), POD_TERMINATION_TIMEOUT);
+    removeLeakableResource(leakedResources, podResource);
+  }, POD_CREATE_DELETE_TIMEOUT);
+
+  it('Node in Maintenance mode is not schedulable', async() => {
+    podResourceOpts.nodeSelector = {'kubernetes.io/hostname': computeNodeHostname};
+    createResource(examplePod(podResourceOpts));
+    addLeakableResource(leakedResources, podResource);
+
+    // Verify Node is marked as in maintenance
+    await browser.get(`${appHost}/k8s/cluster/nodes`);
+    await isLoaded();
+    await browser.wait(until.presenceOf(listViewMaintenanceStatusForNode(computeNodeName)))
+      .then(() => browser.wait(waitForStringInElement(listViewMaintenanceStatusForNode(computeNodeName), NODE_MAINTENANCE_STATUS), PAGE_LOAD_TIMEOUT));
+
+    await pod.navigateToTab(overviewTab);
+    let errorMessage: string;
+    try {
+      await pod.waitForStatusIcon(podView.statusIcons.running, PAGE_LOAD_TIMEOUT);
+    } catch (error) {
+      errorMessage = error.message;
+    }
+    expect(errorMessage).toBe(WAIT_TIMEOUT_ERROR);
+
+    deleteResource(podResource);
+    removeLeakableResource(leakedResources, podResource);
+  }, POD_CREATE_DELETE_TIMEOUT);
+});

--- a/frontend/integration-tests/tests/kubevirt/template.wizard.scenario.ts
+++ b/frontend/integration-tests/tests/kubevirt/template.wizard.scenario.ts
@@ -4,7 +4,8 @@ import { OrderedMap } from 'immutable';
 import { browser} from 'protractor';
 
 // eslint-disable-next-line no-unused-vars
-import { networkResource, provisionOptions, removeLeakedResources, storageResource, VM_BOOTUP_TIMEOUT } from './utils';
+import { networkResource, provisionOptions, removeLeakedResources, storageResource } from './utils/utils';
+import { VM_BOOTUP_TIMEOUT } from './utils/consts';
 import { appHost, testName } from '../../protractor.conf';
 import { statusIcons } from '../../views/kubevirt/virtualMachine.view';
 import { deleteRow, errorMessage, filterForName, isLoaded, resourceRowsPresent } from '../../views/crud.view';

--- a/frontend/integration-tests/tests/kubevirt/utils/consts.ts
+++ b/frontend/integration-tests/tests/kubevirt/utils/consts.ts
@@ -1,0 +1,24 @@
+
+// TIMEOUTS
+const SEC = 1000;
+export const CLONE_VM_TIMEOUT = 300 * SEC;
+export const PAGE_LOAD_TIMEOUT = 15 * SEC;
+export const VM_ACTIONS_TIMEOUT = 120 * SEC;
+export const VM_BOOTUP_TIMEOUT = 90 * SEC;
+export const VM_STOP_TIMEOUT = 6 * SEC;
+export const VM_IP_ASSIGNMENT_TIMEOUT = 180 * SEC;
+export const WINDOWS_IMPORT_TIMEOUT = 150 * SEC;
+
+export const POD_CREATION_TIMEOUT = 40 * SEC;
+export const POD_TERMINATION_TIMEOUT = 30 * SEC;
+export const POD_CREATE_DELETE_TIMEOUT = POD_CREATION_TIMEOUT + POD_TERMINATION_TIMEOUT;
+
+export const NODE_STOP_MAINTENANCE_TIMEOUT = 40 * SEC;
+
+// Exceptions
+export const WAIT_TIMEOUT_ERROR = 'Wait Timeout Error.';
+
+// Compute Nodes
+export const NODE_MAINTENANCE_STATUS = 'Under maintenance';
+export const NODE_STOPPING_MAINTENANCE_STATUS = 'Stopping maintenance';
+export const NODE_READY_STATUS = 'Ready';

--- a/frontend/integration-tests/tests/kubevirt/vm.actions.scenario.ts
+++ b/frontend/integration-tests/tests/kubevirt/vm.actions.scenario.ts
@@ -7,7 +7,8 @@ import { isLoaded, resourceRowsPresent, textFilter } from '../../views/crud.view
 import { listViewAction, getDetailActionDropdownOptions } from '../../views/kubevirt/vm.actions.view';
 import { testNad, hddDisk, networkInterface, getVmManifest } from './mocks';
 import { overviewTab, disksTab, nicsTab, statusIcon, statusIcons, vmDetailNodeID } from '../../views/kubevirt/virtualMachine.view';
-import { removeLeakedResources, deleteResources, createResources, fillInput, searchYAML, waitForCount, VM_BOOTUP_TIMEOUT, VM_STOP_TIMEOUT, VM_ACTIONS_TIMEOUT, PAGE_LOAD_TIMEOUT } from './utils';
+import { removeLeakedResources, deleteResources, createResources, fillInput, searchYAML, waitForCount } from './utils/utils';
+import { VM_BOOTUP_TIMEOUT, VM_STOP_TIMEOUT, VM_ACTIONS_TIMEOUT, PAGE_LOAD_TIMEOUT } from './utils/consts';
 import { VirtualMachine } from './models/virtualMachine';
 
 

--- a/frontend/integration-tests/tests/kubevirt/vm.overview.scenario.ts
+++ b/frontend/integration-tests/tests/kubevirt/vm.overview.scenario.ts
@@ -6,7 +6,7 @@ import { appHost, testName } from '../../protractor.conf';
 import { isLoaded } from '../../views/crud.view';
 import { getVmManifest, basicVmConfig, emptyStr } from './mocks';
 import * as vmView from '../../views/kubevirt/virtualMachine.view';
-import { fillInput, execCommandFromCli, exposeService, selectDropdownOption, asyncForEach } from './utils';
+import { fillInput, execCommandFromCli, exposeService, selectDropdownOption, asyncForEach } from './utils/utils';
 import { VirtualMachine } from './models/virtualMachine';
 
 describe('Test vm overview page', () => {

--- a/frontend/integration-tests/tests/kubevirt/vm.wizard.scenario.ts
+++ b/frontend/integration-tests/tests/kubevirt/vm.wizard.scenario.ts
@@ -4,7 +4,8 @@ import { OrderedMap } from 'immutable';
 import { browser } from 'protractor';
 
 // eslint-disable-next-line no-unused-vars
-import { networkResource, provisionOptions, removeLeakedResources, storageResource, VM_BOOTUP_TIMEOUT } from './utils';
+import { networkResource, provisionOptions, removeLeakedResources, storageResource } from './utils/utils';
+import { VM_BOOTUP_TIMEOUT } from './utils/consts';
 import { appHost, testName } from '../../protractor.conf';
 import { errorMessage, isLoaded } from '../../views/crud.view';
 import { statusIcons } from '../../views/kubevirt/virtualMachine.view';

--- a/frontend/integration-tests/tests/kubevirt/vm.yaml.scenario.ts
+++ b/frontend/integration-tests/tests/kubevirt/vm.yaml.scenario.ts
@@ -5,7 +5,7 @@ import { browser } from 'protractor';
 import { appHost, testName } from '../../protractor.conf';
 import { isLoaded } from '../../views/crud.view';
 import * as yamlView from '../../views/yaml.view';
-import { removeLeakedResources } from './utils';
+import { removeLeakedResources } from './utils/utils';
 import { disksTab, nicsTab } from '../../views/kubevirt/virtualMachine.view';
 import Yaml from './models/yaml';
 import { VirtualMachine } from './models/virtualMachine';

--- a/frontend/integration-tests/tests/kubevirt/windows.scenario.ts
+++ b/frontend/integration-tests/tests/kubevirt/windows.scenario.ts
@@ -2,7 +2,8 @@
 import { execSync } from 'child_process';
 import { browser, ExpectedConditions as until } from 'protractor';
 // eslint-disable-next-line no-unused-vars
-import { removeLeakedResources, waitForStringInElement, VM_IP_ASSIGNMENT_TIMEOUT, WINDOWS_IMPORT_TIMEOUT, VM_BOOTUP_TIMEOUT} from './utils';
+import { removeLeakedResources, waitForStringInElement } from './utils/utils';
+import { VM_IP_ASSIGNMENT_TIMEOUT, WINDOWS_IMPORT_TIMEOUT, VM_BOOTUP_TIMEOUT } from './utils/consts';
 import { testName, appHost } from '../../protractor.conf';
 import { errorMessage, isLoaded } from '../../views/crud.view';
 import { windowsVmConfig, localStorageDisk, multusNetworkInterface, multusNad, localStorageClass, localStoragePersistentVolume } from './mocks';

--- a/frontend/integration-tests/views/kubevirt/node.view.ts
+++ b/frontend/integration-tests/views/kubevirt/node.view.ts
@@ -1,0 +1,4 @@
+import { rowForName } from '../crud.view';
+
+export const listViewReadyStatusForNode = (name: string) => rowForName(name).$('.co-icon-and-text');
+export const listViewMaintenanceStatusForNode = (name: string) => rowForName(name).$('.kubevirt-status__button');

--- a/frontend/integration-tests/views/kubevirt/pod.view.ts
+++ b/frontend/integration-tests/views/kubevirt/pod.view.ts
@@ -1,0 +1,12 @@
+/* eslint-disable no-unused-vars, no-undef */
+import { $ } from 'protractor';
+
+export const statusIcons = {
+  terminating: 'fa-ban',
+  creating: 'pficon-in-progress',
+  pending: 'fa-hourglass-half',
+  running: 'fa-refresh',
+};
+export const statusIcon = (status) => $(`.co-icon-and-text__icon.${status}`);
+
+export const nodeLink = $('[title=Node] + a');

--- a/frontend/integration-tests/views/kubevirt/virtualMachine.view.ts
+++ b/frontend/integration-tests/views/kubevirt/virtualMachine.view.ts
@@ -3,8 +3,6 @@ import { $, $$, by, element, browser, ExpectedConditions as until } from 'protra
 
 import { resourceRows } from '../crud.view';
 
-export const resourceTitle = $('#resource-title');
-
 export const overviewTab = 'Overview';
 export const yamlTab = 'YAML';
 export const consolesTab = 'Consoles';

--- a/frontend/integration-tests/views/kubevirt/wizard.view.ts
+++ b/frontend/integration-tests/views/kubevirt/wizard.view.ts
@@ -1,5 +1,5 @@
 import { $, $$ } from 'protractor';
-import { selectDropdownOption, fillInput } from '../../tests/kubevirt/utils';
+import { selectDropdownOption, fillInput } from '../../tests/kubevirt/utils/utils';
 
 // Wizard Common
 export const closeWizard = $('.modal-footer > button.btn-cancel');


### PR DESCRIPTION
Added test cases for node maintenance.
ATM test cases are implemented with using pods instead of VMs due to lack of testing environment.https://polarion.engineering.redhat.com/polarion/#/project/CNV/wiki/Testing/_UI_%20Node%20Maintenante
