### PR TITLE
[okd-core] Default SERVER_FLAGS.registry

### DIFF
--- a/frontend/public/components/app.jsx
+++ b/frontend/public/components/app.jsx
@@ -25,6 +25,8 @@ import k8sActions, { types } from '../module/k8s/k8s-actions';
 import '../vendor.scss';
 import '../style.scss';
 
+import { initKubevirt } from '../kubevirt/components/init';
+
 //PF4 Imports
 import {
   Page,
@@ -295,6 +297,8 @@ class App extends React.PureComponent {
     );
   }
 }
+
+initKubevirt();
 
 const startDiscovery = () => store.dispatch(k8sActions.watchAPIServices());
 

--- a/frontend/public/kubevirt/components/init.js
+++ b/frontend/public/kubevirt/components/init.js
@@ -1,10 +1,28 @@
-/*
+/* IMPORTANT: this file is patched for downstream builds.
+ * Please keep all changes here compact and synced will downstream patches.
+*/
+
+/**
  Initialization of kubevirt.
 
  Kubevirt is enabled by lazy setting of FLAGS.KUBEVIRT at runtime.
  Following setting takes place before this happens.
 */
 
-// Override default
-// Commandline: ./bin/bridge -branding=okdvirt
-window.SERVER_FLAGS.branding = window.SERVER_FLAGS.branding || 'okdvirt'; // see masthead.tsx, branding.ts, examples/config.yaml, cmd/bridge/main.go
+const REGISTRY_V2V_URL = 'quay.io/nyoxi';
+const REGISTRY_V2V_CONVERSION_TAG = '1.12.1-1-gf665c0a';
+const REGISTRY_V2V_VMWARE_TAG = '1.12.1-1';
+
+const setDefaultRegistry = () => {
+  window.SERVER_FLAGS.registry = window.SERVER_FLAGS.registry || {};
+
+  window.SERVER_FLAGS.registry.v2v = window.SERVER_FLAGS.registry.v2v || {
+    url: REGISTRY_V2V_URL, // TODO: should be moved under quay.io/kubevirt
+    conversionTag: REGISTRY_V2V_CONVERSION_TAG,
+    vmwareTag: REGISTRY_V2V_VMWARE_TAG,
+  };
+};
+
+export const initKubevirt = () => {
+  setDefaultRegistry();
+};


### PR DESCRIPTION
As kubevirt-web-ui handles deployment of the V2V as a temporary workaround
for missing other more suitable "setup component" to do that, the code needs
to be know where/what container images for V2V use.

Future work: either move the deployment logic out of web-ui
or configure registry via ConfigMap and bridge process.

The later option is alligned with changes in this commit.