### PR TITLE
Fix kubevirt status on cluster-overview

### DIFF
--- a/frontend/public/kubevirt/components/cluster/cluster-overview.jsx
+++ b/frontend/public/kubevirt/components/cluster/cluster-overview.jsx
@@ -134,7 +134,7 @@ export class ClusterOverview extends React.Component {
     };
     this.fetchAndStore(`${k8sBasePath}/healthz`, 'k8sHealth', handleK8sHealthResponse, coFetch);
     this.fetchAndStore(
-      `${k8sBasePath}/apis/subresources.${VirtualMachineModel.apiGroup}/${VirtualMachineModel.apiVersion}/healthz`,
+      `/apis/subresources.${VirtualMachineModel.apiGroup}/${VirtualMachineModel.apiVersion}/healthz`,
       'kubevirtHealth'
     );
     this.fetchPrometheusQuery(CEPH_STATUS_QUERY, 'cephHealth');


### PR DESCRIPTION
This PR removes the k8sBasePath from the kubevirt status url

Before this change: api/kubernetes/apis/subresources.kubevirt.io/v1alpha3/healthz
After the change:  apis/subresources.kubevirt.io/v1alpha3/healthz

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubevirt/web-ui/353)
<!-- Reviewable:end -->
