### PR TITLE
[OKD-Core] Check namespace before deleting it

### DIFF
--- a/frontend/integration-tests/protractor.conf.ts
+++ b/frontend/integration-tests/protractor.conf.ts
@@ -84,7 +84,7 @@ export const config: Config = {
     // since we're using kubectl instead of oc.
     const resource = browser.params.openshift === 'true' ? 'projects.project.openshift.io' : 'namespaces';
     await browser.close();
-    execSync(`kubectl delete ${resource} ${testName}`);
+    execSync(`if kubectl get ${resource} ${testName} 2> /dev/null; then kubectl delete ${resource} ${testName}; fi`);
   },
   afterLaunch: (exitCode) => {
     failFast.clean();


### PR DESCRIPTION
We check if the namespace (project) exists before the infrastructure
tries to delete it. This is important because some tests (like the
metalkube tests) don't create a namespace and don't include
base.scenario.ts in the beginning of the suite - so the infrastructure
shouldn't fail in the end when it tries to delete it.