### PR TITLE
Pass virtual machines list to create VM wizard

### DIFF
--- a/frontend/public/kubevirt/components/modals/create-vm-modal.js
+++ b/frontend/public/kubevirt/components/modals/create-vm-modal.js
@@ -9,6 +9,7 @@ import {
   PersistentVolumeClaimModel,
   VmTemplateModel,
   DataVolumeModel,
+  VirtualMachineModel,
 } from '../../models';
 import { WithResources } from '../utils/withResources';
 import { units } from '../utils/okdutils';
@@ -17,6 +18,10 @@ export const openCreateVmWizard = ( activeNamespace, createTemplate = false ) =>
   const launcher = modalResourceLauncher(CreateVmWizard, {
     namespaces: {
       resource: getResource(NamespaceModel),
+    },
+    virtualMachines: {
+      resource: getResource(VirtualMachineModel),
+      required: true,
     },
     userTemplates: {
       resource: getResource(TemplateModel, {namespace: activeNamespace, prop: 'userTemplates', matchLabels: {[TEMPLATE_TYPE_LABEL]: TEMPLATE_TYPE_VM}}),


### PR DESCRIPTION
This PR passes the list of virtual machines to the create VM wizard to enable checking for duplicate VM names.

Bug: https://bugzilla.redhat.com/1697333

Backport of https://github.com/kubevirt/web-ui/pull/367