### PR TITLE
Display correct migration options in kebab

### DIFF
--- a/frontend/public/kubevirt/components/vm/vm.jsx
+++ b/frontend/public/kubevirt/components/vm/vm.jsx
@@ -64,7 +64,7 @@ const VMRow = ({obj: vm}) => {
         resource={vm}
         resources={[
           getResource(VirtualMachineInstanceModel, {name, namespace, isList: false}),
-          migrationResources,
+          getResource(VirtualMachineInstanceMigrationModel, {namespace}),
           getResource(PodModel, { namespace }),
         ]} />
     </div>


### PR DESCRIPTION
This PR corrects an issue where when a VM is migrating, the "Migrate Virtual Machine" option continued to display in the kebab menu and the "Cancel Virtual Machine Migration" option was not displayed.

This was caused by different values being used for the key name. Menu-actions expects the key name to be "VirtualMachineInstanceMigration", but was receiving "migrations" and wasn't able to locate the list of migrations.

Bug: https://bugzilla.redhat.com/1698944

Backport of https://github.com/kubevirt/web-ui/pull/364