### PR TITLE
Add missing actions props to overview header

### DIFF
--- a/frontend/public/kubevirt/components/overview/vm-overview.jsx
+++ b/frontend/public/kubevirt/components/overview/vm-overview.jsx
@@ -21,9 +21,7 @@ const tabs = [
   },
 ];
 
-const ConnctedResourceOverviewDetails = ( props ) => {
-  const { item, pods, migrations, vmi } = props;
-
+const ConnctedResourceOverviewDetails = ({ item, pods, migrations, vmi }) => {
   const actionArgs = {};
   actionArgs[PodModel.kind] = pods;
   actionArgs[VirtualMachineInstanceMigrationModel.kind] = migrations;

--- a/frontend/public/kubevirt/components/overview/vm-overview.jsx
+++ b/frontend/public/kubevirt/components/overview/vm-overview.jsx
@@ -1,10 +1,13 @@
 import React from 'react';
+import * as _ from 'lodash-es';
+import { getResource } from 'kubevirt-web-ui-components';
 
-import { VirtualMachineModel } from '../../../models';
+import { VirtualMachineModel, PodModel, VirtualMachineInstanceMigrationModel, VirtualMachineInstanceModel } from '../../../models';
 import { ResourceOverviewDetails } from '../okdcomponents';
 
 import { menuActions } from '../vm/menu-actions';
 import { ConnectedVmDetails } from '../vm';
+import { WithResources } from '../utils/withResources';
 
 const VirtualMachineOverviewDetails = ({ item }) =>
   <div className="overview__sidebar-pane-body resource-overview__body">
@@ -18,10 +21,46 @@ const tabs = [
   },
 ];
 
-export const VirtualMachineOverviewPage = ({ item }) =>
-  <ResourceOverviewDetails
-    item={item}
-    kindObj={VirtualMachineModel}
-    menuActions={menuActions}
-    tabs={tabs}
-  />;
+const ConnctedResourceOverviewDetails = ( props ) => {
+  const { item, pods, migrations, vmi } = props;
+
+  const actionArgs = {};
+  actionArgs[PodModel.kind] = pods;
+  actionArgs[VirtualMachineInstanceMigrationModel.kind] = migrations;
+  actionArgs[VirtualMachineInstanceModel.kind] = vmi;
+
+  const menuActions_ = _.map(menuActions, m => (kind, vm) => m(kind, vm, actionArgs));
+  return (
+    <ResourceOverviewDetails
+      item={item}
+      kindObj={VirtualMachineModel}
+      menuActions={menuActions_}
+      tabs={tabs}
+    />
+  );
+};
+
+export const VirtualMachineOverviewPage = ({ item }) => {
+  const vm = item.obj;
+  const { name, namespace } = vm.metadata;
+  const resourceMap = {
+    vmi: {
+      resource: getResource(VirtualMachineInstanceModel, {name, namespace, isList: false}),
+      ignoreErrors: true,
+    },
+    pods: {
+      resource: getResource(PodModel, { namespace }),
+    },
+    migrations: {
+      resource: getResource(VirtualMachineInstanceMigrationModel, {namespace}),
+    },
+  };
+
+  return (
+    <WithResources resourceMap={resourceMap}>
+      <ConnctedResourceOverviewDetails
+        item={item}
+      />
+    </WithResources>
+  );
+};


### PR DESCRIPTION
In overview header we need to provide the action args parameter to evaluate the migration action visibility.

BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1708111

Screenshot:
![Peek 2019-05-20 09-39](https://user-images.githubusercontent.com/2181522/58001486-4af1bf00-7ae4-11e9-9ed8-43fde8f382e3.gif)
