### PR TITLE
Protect form missing actionArgs

### DIFF
--- a/frontend/public/kubevirt/components/vm/menu-actions.jsx
+++ b/frontend/public/kubevirt/components/vm/menu-actions.jsx
@@ -73,7 +73,7 @@ const menuActionStop = (kind, vm) => {
 
 const menuActionRestart = (kind, vm, actionArgs) => {
   return {
-    hidden: isImporting(vm, actionArgs) || !(actionArgs[VirtualMachineInstanceModel.kind] && isVmRunning(vm)),
+    hidden: isImporting(vm, actionArgs) || !(actionArgs && actionArgs[VirtualMachineInstanceModel.kind] && isVmRunning(vm)),
     label: 'Restart Virtual Machine',
     callback: () => restartVmModal({
       kind,


### PR DESCRIPTION
**Description**:
In overview we do not send actionArgs, we need to protect menu actions from missing actionArgs.

**Screen shots**:
After:
![Peek 2019-05-19 12-11](https://user-images.githubusercontent.com/2181522/57980160-ebd27280-7a2f-11e9-8545-ba52af5f9793.gif)

Before:
![Peek 2019-05-19 12-14](https://user-images.githubusercontent.com/2181522/57980171-00166f80-7a30-11e9-93bb-2dac39930f6d.gif)
