### PR TITLE
Dashboards page - infrastructure and test

### DIFF
--- a/frontend/integration-tests/protractor.conf.ts
+++ b/frontend/integration-tests/protractor.conf.ts
@@ -91,6 +91,10 @@ export const config: Config = {
     return new Promise(resolve => htmlReporter.afterLaunch(resolve.bind(this, exitCode)));
   },
   suites: {
+    baremetal: [
+      'tests/kubevirt/kubevirt.login.scenario.ts',
+      'tests/metalkube/dashboard.scenario.ts',
+    ],
     filter: [
       'tests/login.scenario.ts',
       'tests/base.scenario.ts',

--- a/frontend/integration-tests/protractor.conf.ts
+++ b/frontend/integration-tests/protractor.conf.ts
@@ -91,7 +91,7 @@ export const config: Config = {
     return new Promise(resolve => htmlReporter.afterLaunch(resolve.bind(this, exitCode)));
   },
   suites: {
-    baremetal: [
+    baremetalSmokeTests: [
       'tests/kubevirt/kubevirt.login.scenario.ts',
       'tests/metalkube/dashboard.scenario.ts',
     ],

--- a/frontend/integration-tests/tests/metalkube/dashboard.scenario.ts
+++ b/frontend/integration-tests/tests/metalkube/dashboard.scenario.ts
@@ -8,34 +8,30 @@ describe('Inventory card', () => {
   it('Node count is displayed', async() => {
     await browser.get(`${appHost}/dashboards`);
     await dashboardView.isLoaded();
-    browser.sleep(10000);
+    browser.sleep(10000); // the counters on the page start updating late...
 
     // get the number of ready and not ready nodes from the CLI
     let readyNodes = 0;
     let notReadyNodes = 0;
     const output = execSync('oc get nodes', { encoding: 'utf-8' });
     const lines = output.split('\n');
-    let i;
-    for (i = 0; i < lines.length; i++) {
-      if (lines[i].indexOf(' Ready ') > 0) {
+    lines.forEach(function(line) {
+      if (line.indexOf(' Ready ') > 0) {
         readyNodes++;
       }
-      if (lines[i].indexOf(' NotReady ') > 0) {
+      if (line.indexOf(' NotReady ') > 0) {
         notReadyNodes++;
       }
-    }
-    expect(await dashboardView.inventoryItemLabel(dashboardView.INVENTORY_NODES).getText()).toEqual(`${readyNodes + notReadyNodes} Nodes`);
-    let upNodes = 0, downNodes = 0;
-    let elem = dashboardView.inventoryUpCounter(dashboardView.INVENTORY_NODES);
-    if (await elem.isPresent()) { // if the counter is 0 the element is not displayed
-      upNodes = Number(await elem.getText());
-    }
-    elem = dashboardView.inventoryDownCounter(dashboardView.INVENTORY_NODES);
-    if (await elem.isPresent()) { // if the counter is 0 the element is not displayed
-      downNodes = Number(await elem.getText());
-    }
-    expect(upNodes === readyNodes).toBe(true);
-    expect(downNodes === notReadyNodes).toBe(true);
+    });
+    const rowNumber = await dashboardView.inventoryRow(dashboardView.INVENTORY_NODES);
+    const inventoryItemLabel = await dashboardView.inventoryItemLabel(rowNumber).getText();
+    expect(inventoryItemLabel).toEqual(`${readyNodes + notReadyNodes} Nodes`);
+    let elem = dashboardView.inventoryUpCounter(rowNumber);
+    const upNodes = Number(await dashboardView.getTextIfPresent(elem, '0'));
+    elem = dashboardView.inventoryDownCounter(rowNumber);
+    const downNodes = Number(await dashboardView.getTextIfPresent(elem, '0'));
+    expect(upNodes).toEqual(readyNodes);
+    expect(downNodes).toEqual(notReadyNodes);
   });
 
   it('Host count is displayed', async() => {
@@ -43,28 +39,24 @@ describe('Inventory card', () => {
     let readyHosts = 0;
     let notReadyHosts = 0;
     const output = execSync('oc get baremetalhosts -n openshift-machine-api', { encoding: 'utf-8' });
-    const lines = output.split('\n');
-    let i;
-    for (i = 1; i < lines.length; i++) {
-      if (lines[i].trim().length > 1) {
-        if (lines[i].indexOf(' OK ') > 0) {
+    const lines = output.split('\n').slice(1); // slice(1) to ignore the 1st line of output
+    lines.forEach(function(line) {
+      if (line.trim().length > 1) {
+        if (line.indexOf(' OK ') > 0) {
           readyHosts++;
         } else {
           notReadyHosts++;
         }
       }
-    }
-    expect(await dashboardView.inventoryItemLabel(dashboardView.INVENTORY_HOSTS).getText()).toEqual(`${readyHosts + notReadyHosts} Hosts`);
-    let upHosts = 0, downHosts = 0;
-    let elem = dashboardView.inventoryUpCounter(dashboardView.INVENTORY_HOSTS);
-    if (await elem.isPresent()) {
-      upHosts = Number(await elem.getText());
-    }
-    elem = dashboardView.inventoryDownCounter(dashboardView.INVENTORY_HOSTS);
-    if (await elem.isPresent()) {
-      downHosts = Number(await elem.getText());
-    }
-    expect(upHosts === readyHosts).toBe(true);
-    expect(downHosts === notReadyHosts).toBe(true);
+    });
+    const rowNumber = await dashboardView.inventoryRow(dashboardView.INVENTORY_HOSTS);
+    const inventoryItemLabel = await dashboardView.inventoryItemLabel(rowNumber).getText();
+    expect(inventoryItemLabel).toEqual(`${readyHosts + notReadyHosts} Hosts`);
+    let elem = dashboardView.inventoryUpCounter(rowNumber);
+    const upHosts = Number(await dashboardView.getTextIfPresent(elem, '0'));
+    elem = dashboardView.inventoryDownCounter(rowNumber);
+    const downHosts = Number(await dashboardView.getTextIfPresent(elem, '0'));
+    expect(upHosts).toEqual(readyHosts);
+    expect(downHosts).toEqual(notReadyHosts);
   });
 });

--- a/frontend/integration-tests/tests/metalkube/dashboard.scenario.ts
+++ b/frontend/integration-tests/tests/metalkube/dashboard.scenario.ts
@@ -5,11 +5,13 @@ import { appHost } from '../../protractor.conf';
 import * as dashboardView from '../../views/metalkube/dashboards.view';
 
 describe('Inventory card', () => {
-  it('Node count is displayed', async() => {
+  beforeAll(async() => {
     await browser.get(`${appHost}/dashboards`);
     await dashboardView.isLoaded();
     browser.sleep(10000); // the counters on the page start updating late...
+  });
 
+  it('Node count is displayed', async() => {
     // get the number of ready and not ready nodes from the CLI
     let readyNodes = 0;
     let notReadyNodes = 0;

--- a/frontend/integration-tests/tests/metalkube/dashboard.scenario.ts
+++ b/frontend/integration-tests/tests/metalkube/dashboard.scenario.ts
@@ -1,0 +1,59 @@
+import { browser } from 'protractor';
+const execSync = require('child_process').execSync;
+
+import { appHost } from '../../protractor.conf';
+import * as dashboardView from '../../views/metalkube/dashboards.view';
+
+describe(`Inventory card`, () => {
+    it('Node count is displayed', async() => {
+        await browser.get(`${appHost}/dashboards`);
+        await dashboardView.isLoaded();
+        browser.sleep(10000);
+
+        // get the number of ready and not ready nodes from the CLI
+        var readyNodes = 0;
+        var notReadyNodes = 0;
+        const output = execSync('oc get nodes', { encoding: 'utf-8' });
+        var lines = output.split("\n");
+        var i;
+        for (i = 0; i < lines.length; i++) {
+          if (lines[i].indexOf(" Ready ") > 0) readyNodes++;
+          if (lines[i].indexOf(" NotReady ") > 0) notReadyNodes++;
+        }
+        expect(await dashboardView.inventoryItemLabel(dashboardView.INVENTORY_NODES).getText()).toEqual(''+ (readyNodes + notReadyNodes) + ' Nodes');
+        var upNodes = 0, downNodes = 0;
+        var elem = dashboardView.inventoryUpCounter(dashboardView.INVENTORY_NODES);
+        if (await elem.isPresent()) // if the counter is 0 the element is not displayed
+            upNodes = Number(await elem.getText());
+        elem = dashboardView.inventoryDownCounter(dashboardView.INVENTORY_NODES);
+        if (await elem.isPresent()) // if the counter is 0 the element is not displayed
+            downNodes = Number(await elem.getText());
+        expect(upNodes === readyNodes).toBe(true);
+        expect(downNodes === notReadyNodes).toBe(true);
+    });
+
+    it('Host count is displayed', async() => {
+        // get the hosts and their statuses from the CLI
+        var readyHosts = 0;
+        var notReadyHosts = 0;
+        const output = execSync('oc get baremetalhosts -n openshift-machine-api', { encoding: 'utf-8' });
+        var lines = output.split("\n");
+        var i;
+        for (i = 1; i < lines.length; i++) {
+          if (lines[i].trim().length > 1) {
+            if (lines[i].indexOf(" OK ") > 0) readyHosts++;
+            else notReadyHosts++;
+          }
+        }
+        expect(await dashboardView.inventoryItemLabel(dashboardView.INVENTORY_HOSTS).getText()).toEqual(''+ (readyHosts + notReadyHosts) + ' Hosts');
+        var upHosts = 0, downHosts = 0;
+        var elem = dashboardView.inventoryUpCounter(dashboardView.INVENTORY_HOSTS);
+        if (await elem.isPresent())
+          upHosts = Number(await elem.getText());
+        elem = dashboardView.inventoryDownCounter(dashboardView.INVENTORY_HOSTS);
+        if (await elem.isPresent())
+          downHosts = Number(await elem.getText());
+        expect(upHosts === readyHosts).toBe(true);
+        expect(downHosts === notReadyHosts).toBe(true);
+    });
+});

--- a/frontend/integration-tests/tests/metalkube/dashboard.scenario.ts
+++ b/frontend/integration-tests/tests/metalkube/dashboard.scenario.ts
@@ -4,6 +4,17 @@ const execSync = require('child_process').execSync;
 import { appHost } from '../../protractor.conf';
 import * as dashboardView from '../../views/metalkube/dashboards.view';
 
+async function expectCounters(rowNumber, upCounterExpected, downCounterExpected, label) {
+  const inventoryItemLabel = await dashboardView.inventoryItemLabel(rowNumber).getText();
+  expect(inventoryItemLabel).toEqual(`${upCounterExpected + downCounterExpected} ${label}`);
+  let elem = dashboardView.inventoryUpCounter(rowNumber);
+  const upHosts = Number(await dashboardView.getTextIfPresent(elem, '0'));
+  elem = dashboardView.inventoryDownCounter(rowNumber);
+  const downHosts = Number(await dashboardView.getTextIfPresent(elem, '0'));
+  expect(upHosts).toEqual(upCounterExpected);
+  expect(downHosts).toEqual(downCounterExpected);
+}
+
 describe('Inventory card', () => {
   beforeAll(async() => {
     await browser.get(`${appHost}/dashboards`);
@@ -26,14 +37,7 @@ describe('Inventory card', () => {
       }
     });
     const rowNumber = await dashboardView.inventoryRow(dashboardView.INVENTORY_NODES);
-    const inventoryItemLabel = await dashboardView.inventoryItemLabel(rowNumber).getText();
-    expect(inventoryItemLabel).toEqual(`${readyNodes + notReadyNodes} Nodes`);
-    let elem = dashboardView.inventoryUpCounter(rowNumber);
-    const upNodes = Number(await dashboardView.getTextIfPresent(elem, '0'));
-    elem = dashboardView.inventoryDownCounter(rowNumber);
-    const downNodes = Number(await dashboardView.getTextIfPresent(elem, '0'));
-    expect(upNodes).toEqual(readyNodes);
-    expect(downNodes).toEqual(notReadyNodes);
+    expectCounters(rowNumber, readyNodes, notReadyNodes, 'Nodes');
   });
 
   it('Host count is displayed', async() => {
@@ -52,13 +56,6 @@ describe('Inventory card', () => {
       }
     });
     const rowNumber = await dashboardView.inventoryRow(dashboardView.INVENTORY_HOSTS);
-    const inventoryItemLabel = await dashboardView.inventoryItemLabel(rowNumber).getText();
-    expect(inventoryItemLabel).toEqual(`${readyHosts + notReadyHosts} Hosts`);
-    let elem = dashboardView.inventoryUpCounter(rowNumber);
-    const upHosts = Number(await dashboardView.getTextIfPresent(elem, '0'));
-    elem = dashboardView.inventoryDownCounter(rowNumber);
-    const downHosts = Number(await dashboardView.getTextIfPresent(elem, '0'));
-    expect(upHosts).toEqual(readyHosts);
-    expect(downHosts).toEqual(notReadyHosts);
+    expectCounters(rowNumber, readyHosts, notReadyHosts, 'Hosts');
   });
 });

--- a/frontend/integration-tests/tests/metalkube/dashboard.scenario.ts
+++ b/frontend/integration-tests/tests/metalkube/dashboard.scenario.ts
@@ -4,56 +4,67 @@ const execSync = require('child_process').execSync;
 import { appHost } from '../../protractor.conf';
 import * as dashboardView from '../../views/metalkube/dashboards.view';
 
-describe(`Inventory card`, () => {
-    it('Node count is displayed', async() => {
-        await browser.get(`${appHost}/dashboards`);
-        await dashboardView.isLoaded();
-        browser.sleep(10000);
+describe('Inventory card', () => {
+  it('Node count is displayed', async() => {
+    await browser.get(`${appHost}/dashboards`);
+    await dashboardView.isLoaded();
+    browser.sleep(10000);
 
-        // get the number of ready and not ready nodes from the CLI
-        var readyNodes = 0;
-        var notReadyNodes = 0;
-        const output = execSync('oc get nodes', { encoding: 'utf-8' });
-        var lines = output.split("\n");
-        var i;
-        for (i = 0; i < lines.length; i++) {
-          if (lines[i].indexOf(" Ready ") > 0) readyNodes++;
-          if (lines[i].indexOf(" NotReady ") > 0) notReadyNodes++;
-        }
-        expect(await dashboardView.inventoryItemLabel(dashboardView.INVENTORY_NODES).getText()).toEqual(''+ (readyNodes + notReadyNodes) + ' Nodes');
-        var upNodes = 0, downNodes = 0;
-        var elem = dashboardView.inventoryUpCounter(dashboardView.INVENTORY_NODES);
-        if (await elem.isPresent()) // if the counter is 0 the element is not displayed
-            upNodes = Number(await elem.getText());
-        elem = dashboardView.inventoryDownCounter(dashboardView.INVENTORY_NODES);
-        if (await elem.isPresent()) // if the counter is 0 the element is not displayed
-            downNodes = Number(await elem.getText());
-        expect(upNodes === readyNodes).toBe(true);
-        expect(downNodes === notReadyNodes).toBe(true);
-    });
+    // get the number of ready and not ready nodes from the CLI
+    let readyNodes = 0;
+    let notReadyNodes = 0;
+    const output = execSync('oc get nodes', { encoding: 'utf-8' });
+    const lines = output.split('\n');
+    let i;
+    for (i = 0; i < lines.length; i++) {
+      if (lines[i].indexOf(' Ready ') > 0) {
+        readyNodes++;
+      }
+      if (lines[i].indexOf(' NotReady ') > 0) {
+        notReadyNodes++;
+      }
+    }
+    expect(await dashboardView.inventoryItemLabel(dashboardView.INVENTORY_NODES).getText()).toEqual(`${readyNodes + notReadyNodes} Nodes`);
+    let upNodes = 0, downNodes = 0;
+    let elem = dashboardView.inventoryUpCounter(dashboardView.INVENTORY_NODES);
+    if (await elem.isPresent()) { // if the counter is 0 the element is not displayed
+      upNodes = Number(await elem.getText());
+    }
+    elem = dashboardView.inventoryDownCounter(dashboardView.INVENTORY_NODES);
+    if (await elem.isPresent()) { // if the counter is 0 the element is not displayed
+      downNodes = Number(await elem.getText());
+    }
+    expect(upNodes === readyNodes).toBe(true);
+    expect(downNodes === notReadyNodes).toBe(true);
+  });
 
-    it('Host count is displayed', async() => {
-        // get the hosts and their statuses from the CLI
-        var readyHosts = 0;
-        var notReadyHosts = 0;
-        const output = execSync('oc get baremetalhosts -n openshift-machine-api', { encoding: 'utf-8' });
-        var lines = output.split("\n");
-        var i;
-        for (i = 1; i < lines.length; i++) {
-          if (lines[i].trim().length > 1) {
-            if (lines[i].indexOf(" OK ") > 0) readyHosts++;
-            else notReadyHosts++;
-          }
+  it('Host count is displayed', async() => {
+    // get the hosts and their statuses from the CLI
+    let readyHosts = 0;
+    let notReadyHosts = 0;
+    const output = execSync('oc get baremetalhosts -n openshift-machine-api', { encoding: 'utf-8' });
+    const lines = output.split('\n');
+    let i;
+    for (i = 1; i < lines.length; i++) {
+      if (lines[i].trim().length > 1) {
+        if (lines[i].indexOf(' OK ') > 0) {
+          readyHosts++;
+        } else {
+          notReadyHosts++;
         }
-        expect(await dashboardView.inventoryItemLabel(dashboardView.INVENTORY_HOSTS).getText()).toEqual(''+ (readyHosts + notReadyHosts) + ' Hosts');
-        var upHosts = 0, downHosts = 0;
-        var elem = dashboardView.inventoryUpCounter(dashboardView.INVENTORY_HOSTS);
-        if (await elem.isPresent())
-          upHosts = Number(await elem.getText());
-        elem = dashboardView.inventoryDownCounter(dashboardView.INVENTORY_HOSTS);
-        if (await elem.isPresent())
-          downHosts = Number(await elem.getText());
-        expect(upHosts === readyHosts).toBe(true);
-        expect(downHosts === notReadyHosts).toBe(true);
-    });
+      }
+    }
+    expect(await dashboardView.inventoryItemLabel(dashboardView.INVENTORY_HOSTS).getText()).toEqual(`${readyHosts + notReadyHosts} Hosts`);
+    let upHosts = 0, downHosts = 0;
+    let elem = dashboardView.inventoryUpCounter(dashboardView.INVENTORY_HOSTS);
+    if (await elem.isPresent()) {
+      upHosts = Number(await elem.getText());
+    }
+    elem = dashboardView.inventoryDownCounter(dashboardView.INVENTORY_HOSTS);
+    if (await elem.isPresent()) {
+      downHosts = Number(await elem.getText());
+    }
+    expect(upHosts === readyHosts).toBe(true);
+    expect(downHosts === notReadyHosts).toBe(true);
+  });
 });

--- a/frontend/integration-tests/views/metalkube/dashboards.view.ts
+++ b/frontend/integration-tests/views/metalkube/dashboards.view.ts
@@ -1,0 +1,101 @@
+import { browser, element, by , $, $$, ExpectedConditions as until } from 'protractor';
+import { waitForNone } from '../../protractor.conf';
+
+export const untilNoLoadersPresent = waitForNone($$('.co-m-loader'));
+export const isLoaded = () => browser.wait(untilNoLoadersPresent).then(() => browser.sleep(2000));
+
+// Usage example:
+// await dashboardView.inventoryItemLabel(dashboardView.INVENTORY_NODES).getText()
+export function inventoryItemLabel(rowNumber) {
+    return element(by.xpath('(//div[@class="kubevirt-inventory__row-title"])[' + (rowNumber + 1) + ']'));
+}
+
+// Usage example:
+// await dashboardView.inventoryUpCounter(dashboardView.INVENTORY_NODES).getText()
+export function inventoryUpCounter(rowNumber) {
+    // Explaining the xpath:
+    // There is an array of 6 kubevirt-inventory__row-status items (one for each line in the inventory).
+    // Then we look for a kubevirt-inventory__row-status-item which has a kubevirt-inventory__row-status-item-icon--ok
+    // under it, and go __back up__ to the parent (with "..") and find the span under it. This gives us
+    // the counter *next to* the kubevirt-inventory__row-status-item-icon--ok.
+    return element(by.xpath('(//div[@class="kubevirt-inventory__row-status"])[' + (rowNumber + 1) + ']' +
+        '/div[contains(@class, "kubevirt-inventory__row-status-item")]' + 
+        '/span[contains(@class, "kubevirt-inventory__row-status-item-icon--ok")]' + 
+        '/../span[contains(@class, "kubevirt-inventory__row-status-item-text")]'));
+}
+
+// Usage example:
+// await dashboardView.inventoryDownCounter(dashboardView.INVENTORY_NODES).getText()
+export function inventoryDownCounter(rowNumber) {
+    // Similar xpath explanation to the one in inventoryUpCounter(), but now we're finding the counter
+    // next to the kubevirt-inventory__row-status-item-icon--error.
+    return element(by.xpath('(//div[@class="kubevirt-inventory__row-status"])[' + (rowNumber + 1) + ']' +
+        '/div[contains(@class, "kubevirt-inventory__row-status-item")]' + 
+        '/span[contains(@class, "kubevirt-inventory__row-status-item-icon--error")]' + 
+        '/../span[contains(@class, "kubevirt-inventory__row-status-item-text")]'));
+}
+
+export const INVENTORY_NODES = 0;
+export const INVENTORY_HOSTS = 1;
+export const INVENTORY_PVCS  = 2;
+export const INVENTORY_PODS  = 3;
+export const INVENTORY_VMS   = 4;
+export const INVENTORY_DISKS = 5;
+
+// Usage example:
+// await dashboardView.sysEventTime(0).getText()
+export function sysEventTime(rowNumber) {
+    return element(by.xpath('(//div[@class="co-sysevent__header"])[' + (rowNumber + 1) + ']/small'));
+}
+
+// Usage example:
+// await dashboardView.sysEventIcon(0).getAttribute('class')
+export function sysEventIcon(rowNumber) {
+    return element(by.xpath('(//div[@class="co-sysevent__subheader"])[' + (rowNumber + 1) + ']/span[1]'));
+}
+
+// Usage example:
+// await dashboardView.sysEventResourceIcon(0).getAttribute('class')
+export function sysEventResourceIcon(rowNumber) {
+    return element(by.xpath('(//div[@class="co-sysevent__subheader"])[' + (rowNumber + 1) + ']' +
+        '/span[contains(@class, "co-sysevent__resourcelink")]' +
+        '/span[contains(@class, "co-m-resource-icon")]'));
+}
+
+// Usage example:
+// await dashboardView.sysEventResourceName(0).getText()
+export function sysEventResourceName(rowNumber) {
+    return element(by.xpath('(//div[@class="co-sysevent__subheader"])[' + (rowNumber + 1) + ']' +
+        '/span[contains(@class, "co-sysevent__resourcelink")]' +
+        '/a[@class="co-resource-item__resource-name"]'));
+}
+
+// Usage example:
+// await dashboardView.sysEventSource(0).getText()
+export function sysEventSource(rowNumber) {
+    return element(by.xpath('(//div[@class="co-sysevent__header"])[' + (rowNumber + 1) + ']' +
+        '/div[@class="co-sysevent__details"]' +
+        '/small[@class="co-sysevent__source"]'));
+}
+
+// Usage example:
+// await dashboardView.sysEventMessage(0).getText()
+export function sysEventMessage(rowNumber) {
+    return element(by.xpath('(//div[contains(@class, "co-sysevent__message")])[' + (rowNumber + 1) + ']'));
+}
+
+// Usage example:
+// await dashboardView.alertItemIcon(0).getAttribute('class')
+export function alertItemIcon(rowNumber) {
+    return element(by.xpath('//div[@class="kubevirt-alert__alerts-body"]' +
+        '/div[@class="kubevirt-alert__item"][' + (rowNumber + 1) + ']' +
+        '/span'));
+}
+
+// Usage example:
+// await dashboardView.alertItemMessage(0).getText()
+export function alertItemMessage(rowNumber) {
+    return element(by.xpath('//div[@class="kubevirt-alert__alerts-body"]' +
+        '/div[@class="kubevirt-alert__item"][' + (rowNumber + 1) + ']' +
+        '/div[@class="kubevirt-alert__item-message"]'));
+}

--- a/frontend/integration-tests/views/metalkube/dashboards.view.ts
+++ b/frontend/integration-tests/views/metalkube/dashboards.view.ts
@@ -1,4 +1,4 @@
-import { browser, element, by , $, $$, ExpectedConditions as until } from 'protractor';
+import { browser, element, by , $$ } from 'protractor';
 import { waitForNone } from '../../protractor.conf';
 
 export const untilNoLoadersPresent = waitForNone($$('.co-m-loader'));
@@ -7,95 +7,95 @@ export const isLoaded = () => browser.wait(untilNoLoadersPresent).then(() => bro
 // Usage example:
 // await dashboardView.inventoryItemLabel(dashboardView.INVENTORY_NODES).getText()
 export function inventoryItemLabel(rowNumber) {
-    return element(by.xpath('(//div[@class="kubevirt-inventory__row-title"])[' + (rowNumber + 1) + ']'));
+  return element(by.xpath(`(//div[@class="kubevirt-inventory__row-title"])[${rowNumber + 1}]`));
 }
 
 // Usage example:
 // await dashboardView.inventoryUpCounter(dashboardView.INVENTORY_NODES).getText()
 export function inventoryUpCounter(rowNumber) {
-    // Explaining the xpath:
-    // There is an array of 6 kubevirt-inventory__row-status items (one for each line in the inventory).
-    // Then we look for a kubevirt-inventory__row-status-item which has a kubevirt-inventory__row-status-item-icon--ok
-    // under it, and go __back up__ to the parent (with "..") and find the span under it. This gives us
-    // the counter *next to* the kubevirt-inventory__row-status-item-icon--ok.
-    return element(by.xpath('(//div[@class="kubevirt-inventory__row-status"])[' + (rowNumber + 1) + ']' +
-        '/div[contains(@class, "kubevirt-inventory__row-status-item")]' + 
-        '/span[contains(@class, "kubevirt-inventory__row-status-item-icon--ok")]' + 
-        '/../span[contains(@class, "kubevirt-inventory__row-status-item-text")]'));
+  // Explaining the xpath:
+  // There is an array of 6 kubevirt-inventory__row-status items (one for each line in the inventory).
+  // Then we look for a kubevirt-inventory__row-status-item which has a kubevirt-inventory__row-status-item-icon--ok
+  // under it, and go __back up__ to the parent (with "..") and find the span under it. This gives us
+  // the counter *next to* the kubevirt-inventory__row-status-item-icon--ok.
+  return element(by.xpath(`(//div[@class="kubevirt-inventory__row-status"])[${rowNumber + 1}]` +
+    '/div[contains(@class, "kubevirt-inventory__row-status-item")]' +
+    '/span[contains(@class, "kubevirt-inventory__row-status-item-icon--ok")]' +
+    '/../span[contains(@class, "kubevirt-inventory__row-status-item-text")]'));
 }
 
 // Usage example:
 // await dashboardView.inventoryDownCounter(dashboardView.INVENTORY_NODES).getText()
 export function inventoryDownCounter(rowNumber) {
-    // Similar xpath explanation to the one in inventoryUpCounter(), but now we're finding the counter
-    // next to the kubevirt-inventory__row-status-item-icon--error.
-    return element(by.xpath('(//div[@class="kubevirt-inventory__row-status"])[' + (rowNumber + 1) + ']' +
-        '/div[contains(@class, "kubevirt-inventory__row-status-item")]' + 
-        '/span[contains(@class, "kubevirt-inventory__row-status-item-icon--error")]' + 
-        '/../span[contains(@class, "kubevirt-inventory__row-status-item-text")]'));
+  // Similar xpath explanation to the one in inventoryUpCounter(), but now we're finding the counter
+  // next to the kubevirt-inventory__row-status-item-icon--error.
+  return element(by.xpath(`(//div[@class="kubevirt-inventory__row-status"])[${rowNumber + 1}]` +
+    '/div[contains(@class, "kubevirt-inventory__row-status-item")]' +
+    '/span[contains(@class, "kubevirt-inventory__row-status-item-icon--error")]' +
+    '/../span[contains(@class, "kubevirt-inventory__row-status-item-text")]'));
 }
 
 export const INVENTORY_NODES = 0;
 export const INVENTORY_HOSTS = 1;
-export const INVENTORY_PVCS  = 2;
-export const INVENTORY_PODS  = 3;
-export const INVENTORY_VMS   = 4;
+export const INVENTORY_PVCS = 2;
+export const INVENTORY_PODS = 3;
+export const INVENTORY_VMS = 4;
 export const INVENTORY_DISKS = 5;
 
 // Usage example:
 // await dashboardView.sysEventTime(0).getText()
 export function sysEventTime(rowNumber) {
-    return element(by.xpath('(//div[@class="co-sysevent__header"])[' + (rowNumber + 1) + ']/small'));
+  return element(by.xpath(`(//div[@class="co-sysevent__header"])[${rowNumber + 1}]/small`));
 }
 
 // Usage example:
 // await dashboardView.sysEventIcon(0).getAttribute('class')
 export function sysEventIcon(rowNumber) {
-    return element(by.xpath('(//div[@class="co-sysevent__subheader"])[' + (rowNumber + 1) + ']/span[1]'));
+  return element(by.xpath(`(//div[@class="co-sysevent__subheader"])[${rowNumber + 1}]/span[1]`));
 }
 
 // Usage example:
 // await dashboardView.sysEventResourceIcon(0).getAttribute('class')
 export function sysEventResourceIcon(rowNumber) {
-    return element(by.xpath('(//div[@class="co-sysevent__subheader"])[' + (rowNumber + 1) + ']' +
-        '/span[contains(@class, "co-sysevent__resourcelink")]' +
-        '/span[contains(@class, "co-m-resource-icon")]'));
+  return element(by.xpath(`(//div[@class="co-sysevent__subheader"])[${rowNumber + 1}]` +
+    '/span[contains(@class, "co-sysevent__resourcelink")]' +
+    '/span[contains(@class, "co-m-resource-icon")]'));
 }
 
 // Usage example:
 // await dashboardView.sysEventResourceName(0).getText()
 export function sysEventResourceName(rowNumber) {
-    return element(by.xpath('(//div[@class="co-sysevent__subheader"])[' + (rowNumber + 1) + ']' +
-        '/span[contains(@class, "co-sysevent__resourcelink")]' +
-        '/a[@class="co-resource-item__resource-name"]'));
+  return element(by.xpath(`(//div[@class="co-sysevent__subheader"])[${rowNumber + 1}]` +
+    '/span[contains(@class, "co-sysevent__resourcelink")]' +
+    '/a[@class="co-resource-item__resource-name"]'));
 }
 
 // Usage example:
 // await dashboardView.sysEventSource(0).getText()
 export function sysEventSource(rowNumber) {
-    return element(by.xpath('(//div[@class="co-sysevent__header"])[' + (rowNumber + 1) + ']' +
-        '/div[@class="co-sysevent__details"]' +
-        '/small[@class="co-sysevent__source"]'));
+  return element(by.xpath(`(//div[@class="co-sysevent__header"])[${rowNumber + 1}]` +
+    '/div[@class="co-sysevent__details"]' +
+    '/small[@class="co-sysevent__source"]'));
 }
 
 // Usage example:
 // await dashboardView.sysEventMessage(0).getText()
 export function sysEventMessage(rowNumber) {
-    return element(by.xpath('(//div[contains(@class, "co-sysevent__message")])[' + (rowNumber + 1) + ']'));
+  return element(by.xpath(`(//div[contains(@class, "co-sysevent__message")])[${rowNumber + 1}]`));
 }
 
 // Usage example:
 // await dashboardView.alertItemIcon(0).getAttribute('class')
 export function alertItemIcon(rowNumber) {
-    return element(by.xpath('//div[@class="kubevirt-alert__alerts-body"]' +
-        '/div[@class="kubevirt-alert__item"][' + (rowNumber + 1) + ']' +
-        '/span'));
+  return element(by.xpath('//div[@class="kubevirt-alert__alerts-body"]' +
+    `/div[@class="kubevirt-alert__item"][${rowNumber + 1}]` +
+    '/span'));
 }
 
 // Usage example:
 // await dashboardView.alertItemMessage(0).getText()
 export function alertItemMessage(rowNumber) {
-    return element(by.xpath('//div[@class="kubevirt-alert__alerts-body"]' +
-        '/div[@class="kubevirt-alert__item"][' + (rowNumber + 1) + ']' +
-        '/div[@class="kubevirt-alert__item-message"]'));
+  return element(by.xpath('//div[@class="kubevirt-alert__alerts-body"]' +
+    `/div[@class="kubevirt-alert__item"][${rowNumber + 1}]` +
+    '/div[@class="kubevirt-alert__item-message"]'));
 }

--- a/frontend/integration-tests/views/metalkube/dashboards.view.ts
+++ b/frontend/integration-tests/views/metalkube/dashboards.view.ts
@@ -4,14 +4,23 @@ import { waitForNone } from '../../protractor.conf';
 export const untilNoLoadersPresent = waitForNone($$('.co-m-loader'));
 export const isLoaded = () => browser.wait(untilNoLoadersPresent).then(() => browser.sleep(2000));
 
-// Usage example:
-// await dashboardView.inventoryItemLabel(0).getText()
+/**
+ * The label element in the nth row in the inventory card, which also says the total count of the
+ * items of the resource type (for example: "6 Nodes")
+ * @example
+ * await dashboardView.inventoryItemLabel(0).getText()
+ */
 export function inventoryItemLabel(rowNumber) {
   return element(by.xpath(`(//div[@class="kubevirt-inventory__row-title"])[${rowNumber + 1}]`));
 }
 
-// Usage example:
-// await dashboardView.inventoryUpCounter(0).getText()
+/**
+ * The element in the inventory card, next to the up icon (green check icon) in the nth row.
+ * This element doesn't always exist, so check if it's present first, or use the getTextIfPresent
+ * utility function.
+ * @example
+ * await dashboardView.inventoryUpCounter(0).getText()
+ */
 export function inventoryUpCounter(rowNumber) {
   // Explaining the xpath:
   // There is an array of 6 kubevirt-inventory__row-status items (one for each line in the inventory).
@@ -24,8 +33,13 @@ export function inventoryUpCounter(rowNumber) {
     '/../span[contains(@class, "kubevirt-inventory__row-status-item-text")]'));
 }
 
-// Usage example:
-// await dashboardView.inventoryDownCounter(0).getText()
+/**
+ * The element in the inventory card, next to the down icon (red error icon) in the nth row.
+ * This element doesn't always exist, so check if it's present first, or use the getTextIfPresent
+ * utility function.
+ * @example
+ * await dashboardView.inventoryDownCounter(0).getText()
+ */
 export function inventoryDownCounter(rowNumber) {
   // Similar xpath explanation to the one in inventoryUpCounter(), but now we're finding the counter
   // next to the kubevirt-inventory__row-status-item-icon--error.
@@ -43,8 +57,11 @@ export const INVENTORY_PODS = ' Pods';
 export const INVENTORY_VMS = ' VMs';
 export const INVENTORY_DISKS = ' Disks';
 
-// Usage example:
-// const rowNumber = await dashboardView.inventoryRow(dashboardView.INVENTORY_HOSTS);
+/**
+ * Find the inventory row in the inventory card (depends on what you have installed)
+ * @example
+ * const rowNumber = await dashboardView.inventoryRow(dashboardView.INVENTORY_HOSTS);
+ */
 export const inventoryRow = async(substrInventory) => {
   const elements = await $$('.kubevirt-inventory__row-title');
   let i; // not using a forEach loop because you can't break or return from it
@@ -58,58 +75,82 @@ export const inventoryRow = async(substrInventory) => {
   }
 };
 
-// Usage example:
-// await dashboardView.sysEventTime(0).getText()
+/**
+ * Get time of (nth) system event
+ * @example
+ * await dashboardView.sysEventTime(0).getText()
+ */
 export function sysEventTime(rowNumber) {
   return element(by.xpath(`(//div[@class="co-sysevent__header"])[${rowNumber + 1}]/small`));
 }
 
-// Usage example:
-// await dashboardView.sysEventIcon(0).getAttribute('class')
+/**
+ * Get icon of (nth) system event
+ * @example
+ * await dashboardView.sysEventIcon(0).getAttribute('class')
+ */
 export function sysEventIcon(rowNumber) {
   return element(by.xpath(`(//div[@class="co-sysevent__subheader"])[${rowNumber + 1}]/span[1]`));
 }
 
-// Usage example:
-// await dashboardView.sysEventResourceIcon(0).getAttribute('class')
+/**
+ * Get the resource icon of (nth) system event
+ * @example
+ * await dashboardView.sysEventResourceIcon(0).getAttribute('class')
+ */
 export function sysEventResourceIcon(rowNumber) {
   return element(by.xpath(`(//div[@class="co-sysevent__subheader"])[${rowNumber + 1}]` +
     '/span[contains(@class, "co-sysevent__resourcelink")]' +
     '/span[contains(@class, "co-m-resource-icon")]'));
 }
 
-// Usage example:
-// await dashboardView.sysEventResourceName(0).getText()
+/**
+ * Get the resource name of (nth) system event
+ * @example
+ * await dashboardView.sysEventResourceName(0).getText()
+ */
 export function sysEventResourceName(rowNumber) {
   return element(by.xpath(`(//div[@class="co-sysevent__subheader"])[${rowNumber + 1}]` +
     '/span[contains(@class, "co-sysevent__resourcelink")]' +
     '/a[@class="co-resource-item__resource-name"]'));
 }
 
-// Usage example:
-// await dashboardView.sysEventSource(0).getText()
+/**
+ * Get the source of (nth) system event
+ * @example
+ * await dashboardView.sysEventSource(0).getText()
+ */
 export function sysEventSource(rowNumber) {
   return element(by.xpath(`(//div[@class="co-sysevent__header"])[${rowNumber + 1}]` +
     '/div[@class="co-sysevent__details"]' +
     '/small[@class="co-sysevent__source"]'));
 }
 
-// Usage example:
-// await dashboardView.sysEventMessage(0).getText()
+/**
+ * Get the message text of (nth) system event
+ * @example
+ * await dashboardView.sysEventMessage(0).getText()
+ */
 export function sysEventMessage(rowNumber) {
   return element(by.xpath(`(//div[contains(@class, "co-sysevent__message")])[${rowNumber + 1}]`));
 }
 
-// Usage example:
-// await dashboardView.alertItemIcon(0).getAttribute('class')
+/**
+ * Get the alert item icon of (nth) alert
+ * @example
+ * await dashboardView.alertItemIcon(0).getAttribute('class')
+ */
 export function alertItemIcon(rowNumber) {
   return element(by.xpath('//div[@class="kubevirt-alert__alerts-body"]' +
     `/div[@class="kubevirt-alert__item"][${rowNumber + 1}]` +
     '/span'));
 }
 
-// Usage example:
-// await dashboardView.alertItemMessage(0).getText()
+/**
+ * Get the alert message text (nth) alert
+ * @example
+ * await dashboardView.alertItemMessage(0).getText()
+ */
 export function alertItemMessage(rowNumber) {
   return element(by.xpath('//div[@class="kubevirt-alert__alerts-body"]' +
     `/div[@class="kubevirt-alert__item"][${rowNumber + 1}]` +

--- a/frontend/integration-tests/views/metalkube/dashboards.view.ts
+++ b/frontend/integration-tests/views/metalkube/dashboards.view.ts
@@ -5,13 +5,13 @@ export const untilNoLoadersPresent = waitForNone($$('.co-m-loader'));
 export const isLoaded = () => browser.wait(untilNoLoadersPresent).then(() => browser.sleep(2000));
 
 // Usage example:
-// await dashboardView.inventoryItemLabel(dashboardView.INVENTORY_NODES).getText()
+// await dashboardView.inventoryItemLabel(0).getText()
 export function inventoryItemLabel(rowNumber) {
   return element(by.xpath(`(//div[@class="kubevirt-inventory__row-title"])[${rowNumber + 1}]`));
 }
 
 // Usage example:
-// await dashboardView.inventoryUpCounter(dashboardView.INVENTORY_NODES).getText()
+// await dashboardView.inventoryUpCounter(0).getText()
 export function inventoryUpCounter(rowNumber) {
   // Explaining the xpath:
   // There is an array of 6 kubevirt-inventory__row-status items (one for each line in the inventory).
@@ -25,7 +25,7 @@ export function inventoryUpCounter(rowNumber) {
 }
 
 // Usage example:
-// await dashboardView.inventoryDownCounter(dashboardView.INVENTORY_NODES).getText()
+// await dashboardView.inventoryDownCounter(0).getText()
 export function inventoryDownCounter(rowNumber) {
   // Similar xpath explanation to the one in inventoryUpCounter(), but now we're finding the counter
   // next to the kubevirt-inventory__row-status-item-icon--error.
@@ -35,12 +35,28 @@ export function inventoryDownCounter(rowNumber) {
     '/../span[contains(@class, "kubevirt-inventory__row-status-item-text")]'));
 }
 
-export const INVENTORY_NODES = 0;
-export const INVENTORY_HOSTS = 1;
-export const INVENTORY_PVCS = 2;
-export const INVENTORY_PODS = 3;
-export const INVENTORY_VMS = 4;
-export const INVENTORY_DISKS = 5;
+// substrings to identify the rows in the inventory card
+export const INVENTORY_NODES = ' Nodes';
+export const INVENTORY_HOSTS = ' Hosts';
+export const INVENTORY_PVCS = ' PVCs';
+export const INVENTORY_PODS = ' Pods';
+export const INVENTORY_VMS = ' VMs';
+export const INVENTORY_DISKS = ' Disks';
+
+// Usage example:
+// const rowNumber = await dashboardView.inventoryRow(dashboardView.INVENTORY_HOSTS);
+export const inventoryRow = async(substrInventory) => {
+  const elements = await $$('.kubevirt-inventory__row-title');
+  let i; // not using a forEach loop because you can't break or return from it
+  for (i = 0; i < elements.length; i++) {
+    const inventoryLabel = await elements[i].getText();
+    if (inventoryLabel.indexOf(substrInventory) > -1) {
+      return new Promise(resolve => {
+        resolve(i);
+      });
+    }
+  }
+};
 
 // Usage example:
 // await dashboardView.sysEventTime(0).getText()
@@ -98,4 +114,14 @@ export function alertItemMessage(rowNumber) {
   return element(by.xpath('//div[@class="kubevirt-alert__alerts-body"]' +
     `/div[@class="kubevirt-alert__item"][${rowNumber + 1}]` +
     '/div[@class="kubevirt-alert__item-message"]'));
+}
+
+// Utility function: getTextIfPresent
+export async function getTextIfPresent(elem, textIfNotPresent='') {
+  if (await elem.isPresent()) {
+    return elem.getText();
+  }
+  return new Promise(resolve => {
+    resolve(textIfNotPresent);
+  });
 }


### PR DESCRIPTION
This adds the basic infrastructure to interact with the elements in the
dashboards page. It is still WIP and currently includes support for:

1) Reading the inventory and statuses of the inventory items (hosts and
   nodes, for example, and how many of them are up and how many down)
2) Reading the events (such as pod started, pod stopped etc...)
3) Reading the alerts (such as storage space low etc...)
4) A small test is included, which tests that the nodes and hosts in
   the inventory match what you get from the CLI