### PR TITLE
Add TC to check DV is cloned when VM is created from template

### DIFF
--- a/frontend/integration-tests/tests/kubevirt/mocks.ts
+++ b/frontend/integration-tests/tests/kubevirt/mocks.ts
@@ -5,160 +5,6 @@ import { cloudInitConfig } from './utils/utils';
 
 export const emptyStr = '---';
 
-export function getVmManifest(provisionSource: string, namespace: string, name?: string, cloudinit?: string) {
-  const metadata = {
-    name: name ? name : `${provisionSource.toLowerCase()}-${namespace.slice(-5)}`,
-    annotations: {
-      'name.os.template.kubevirt.io/rhel7.0': 'Red Hat Enterprise Linux 7.0',
-      description: namespace,
-    },
-    namespace,
-    labels: {
-      'app': `vm-${provisionSource.toLowerCase()}-${namespace}`,
-      'flavor.template.kubevirt.io/small': 'true',
-      'os.template.kubevirt.io/rhel7.0': 'true',
-      'vm.kubevirt.io/template': 'rhel7-generic-small',
-      'vm.kubevirt.io/template-namespace': 'openshift',
-      'workload.template.kubevirt.io/generic': 'true',
-    },
-  };
-  const urlSource = {
-    http: {
-      url: 'https://download.cirros-cloud.net/0.4.0/cirros-0.4.0-x86_64-disk.img',
-    },
-  };
-  const dataVolumeTemplate = {
-    metadata: {
-      name: `${metadata.name}-rootdisk`,
-    },
-    spec: {
-      pvc: {
-        accessModes: [
-          'ReadWriteOnce',
-        ],
-        resources: {
-          requests: {
-            storage: '1Gi',
-          },
-        },
-      },
-      source: {},
-    },
-  };
-  const dataVolume = {
-    dataVolume: {
-      name: `${metadata.name}-rootdisk`,
-    },
-    name: 'rootdisk',
-  };
-  const containerDisk = {
-    containerDisk: {
-      image: 'kubevirt/cirros-registry-disk-demo:latest',
-    },
-    name: 'rootdisk',
-  };
-  const cloudInitNoCloud = {
-    cloudInitNoCloud: {
-      userData: cloudinit,
-    },
-    name: 'cloudinitdisk',
-  };
-  const rootdisk = {
-    bootOrder: 1,
-    disk: {
-      bus: 'virtio',
-    },
-    name: 'rootdisk',
-  };
-  const cloudinitdisk = {
-    bootOrder: 3,
-    disk: {
-      bus: 'virtio',
-    },
-    name: 'cloudinitdisk',
-  };
-
-  const dataVolumeTemplates = [];
-  const volumes = [];
-  const disks = [];
-
-  disks.push(rootdisk);
-
-  if (cloudinit) {
-    volumes.push(cloudInitNoCloud);
-    disks.push(cloudinitdisk);
-  }
-
-  switch (provisionSource) {
-    case 'URL':
-      dataVolumeTemplate.spec.source = urlSource;
-      dataVolumeTemplates.push(dataVolumeTemplate);
-      volumes.push(dataVolume);
-      break;
-    case 'PXE':
-      dataVolumeTemplate.spec.source = { blank: {} };
-      dataVolumeTemplates.push(dataVolumeTemplate);
-      volumes.push(dataVolume);
-      break;
-    case 'Container':
-      volumes.push(containerDisk);
-      break;
-    default:
-      throw Error('Provision source not Implemented');
-  }
-
-  const vmResource = {
-    apiVersion: 'kubevirt.io/v1alpha3',
-    kind: 'VirtualMachine',
-    metadata,
-    spec: {
-      dataVolumeTemplates,
-      running: false,
-      template: {
-        metadata: {
-          labels: {
-            'vm.kubevirt.io/name': metadata.name,
-          },
-        },
-        spec : {
-          domain: {
-            cpu: {
-              cores: 1,
-              sockets: 1,
-              threads: 1,
-            },
-            devices: {
-              disks,
-              interfaces: [
-                {
-                  bootOrder: 2,
-                  masquerade: {},
-                  name: 'nic0',
-                },
-              ],
-              rng: {},
-            },
-            resources: {
-              requests: {
-                memory: '2G',
-              },
-            },
-          },
-          terminationGracePeriodSeconds: 0,
-          networks: [
-            {
-              name: 'nic0',
-              pod: {},
-            },
-          ],
-          volumes,
-        },
-      },
-    },
-  };
-  return vmResource;
-}
-
 export const testNad = {
   apiVersion: 'k8s.cni.cncf.io/v1',
   kind: 'NetworkAttachmentDefinition',
@@ -360,6 +206,161 @@ export const examplePod = ({name, namespace, nodeSelector}) => {
     },
   };
 };
+
+export function getVmManifest(provisionSource: string, namespace: string, name?: string, cloudinit?: string) {
+  const metadata = {
+    name: name ? name : `${provisionSource.toLowerCase()}-${namespace.slice(-5)}`,
+    annotations: {
+      'name.os.template.kubevirt.io/rhel7.0': 'Red Hat Enterprise Linux 7.0',
+      description: namespace,
+    },
+    namespace,
+    labels: {
+      'app': `vm-${provisionSource.toLowerCase()}-${namespace}`,
+      'flavor.template.kubevirt.io/small': 'true',
+      'os.template.kubevirt.io/rhel7.0': 'true',
+      'vm.kubevirt.io/template': 'rhel7-generic-small',
+      'vm.kubevirt.io/template-namespace': 'openshift',
+      'workload.template.kubevirt.io/generic': 'true',
+    },
+  };
+  const urlSource = {
+    http: {
+      url: 'https://download.cirros-cloud.net/0.4.0/cirros-0.4.0-x86_64-disk.img',
+    },
+  };
+  const dataVolumeTemplate = {
+    metadata: {
+      name: `${metadata.name}-rootdisk`,
+    },
+    spec: {
+      pvc: {
+        accessModes: [
+          'ReadWriteOnce',
+        ],
+        resources: {
+          requests: {
+            storage: '1Gi',
+          },
+        },
+        storageClassName: `${rootDisk.storageClass}`,
+      },
+      source: {},
+    },
+  };
+  const dataVolume = {
+    dataVolume: {
+      name: `${metadata.name}-rootdisk`,
+    },
+    name: 'rootdisk',
+  };
+  const containerDisk = {
+    containerDisk: {
+      image: 'kubevirt/cirros-registry-disk-demo:latest',
+    },
+    name: 'rootdisk',
+  };
+  const cloudInitNoCloud = {
+    cloudInitNoCloud: {
+      userData: cloudinit,
+    },
+    name: 'cloudinitdisk',
+  };
+  const rootdisk = {
+    bootOrder: 1,
+    disk: {
+      bus: 'virtio',
+    },
+    name: 'rootdisk',
+  };
+  const cloudinitdisk = {
+    bootOrder: 3,
+    disk: {
+      bus: 'virtio',
+    },
+    name: 'cloudinitdisk',
+  };
+
+  const dataVolumeTemplates = [];
+  const volumes = [];
+  const disks = [];
+
+  disks.push(rootdisk);
+
+  if (cloudinit) {
+    volumes.push(cloudInitNoCloud);
+    disks.push(cloudinitdisk);
+  }
+
+  switch (provisionSource) {
+    case 'URL':
+      dataVolumeTemplate.spec.source = urlSource;
+      dataVolumeTemplates.push(dataVolumeTemplate);
+      volumes.push(dataVolume);
+      break;
+    case 'PXE':
+      dataVolumeTemplate.spec.source = { blank: {} };
+      dataVolumeTemplates.push(dataVolumeTemplate);
+      volumes.push(dataVolume);
+      break;
+    case 'Container':
+      volumes.push(containerDisk);
+      break;
+    default:
+      throw Error('Provision source not Implemented');
+  }
+
+  const vmResource = {
+    apiVersion: 'kubevirt.io/v1alpha3',
+    kind: 'VirtualMachine',
+    metadata,
+    spec: {
+      dataVolumeTemplates,
+      running: false,
+      template: {
+        metadata: {
+          labels: {
+            'vm.kubevirt.io/name': metadata.name,
+          },
+        },
+        spec : {
+          domain: {
+            cpu: {
+              cores: 1,
+              sockets: 1,
+              threads: 1,
+            },
+            devices: {
+              disks,
+              interfaces: [
+                {
+                  bootOrder: 2,
+                  masquerade: {},
+                  name: 'nic0',
+                },
+              ],
+              rng: {},
+            },
+            resources: {
+              requests: {
+                memory: '2G',
+              },
+            },
+          },
+          terminationGracePeriodSeconds: 0,
+          networks: [
+            {
+              name: 'nic0',
+              pod: {},
+            },
+          ],
+          volumes,
+        },
+      },
+    },
+  };
+  return vmResource;
+}
 
 export const customVMWithNicDisk = `
 apiVersion: kubevirt.io/v1alpha3

--- a/frontend/integration-tests/tests/kubevirt/models/detailView.ts
+++ b/frontend/integration-tests/tests/kubevirt/models/detailView.ts
@@ -10,10 +10,10 @@ export class DetailView {
   readonly namespace: string;
   readonly kind: string;
 
-  constructor(name: string, namespace: string, kind: string) {
-    this.name = name;
-    this.namespace = namespace;
-    this.kind = kind;
+  constructor(instance) {
+    this.name = instance.name;
+    this.namespace = instance.namespace;
+    this.kind = instance.kind;
   }
 
   static async getResourceTitle() {

--- a/frontend/integration-tests/tests/kubevirt/models/kubevirtDetailView.ts
+++ b/frontend/integration-tests/tests/kubevirt/models/kubevirtDetailView.ts
@@ -9,6 +9,10 @@ import { browser } from 'protractor';
 
 
 export class KubevirtDetailView extends DetailView {
+  constructor(instanceConfig) {
+    super(instanceConfig);
+  }
+
   // TODO: Deprecate getAttachedResources and use specific methods instead (getAttachedDisks/getAttachedNics)
   async getAttachedResources(resourceTab: string): Promise<string[]> {
     await this.navigateToTab(resourceTab);

--- a/frontend/integration-tests/tests/kubevirt/models/pod.ts
+++ b/frontend/integration-tests/tests/kubevirt/models/pod.ts
@@ -9,8 +9,8 @@ import { detailViewAction } from '../../../views/kubevirt/vm.actions.view';
 import { statusIcon } from '../../../views/kubevirt/pod.view';
 
 export default class Pod extends DetailView {
-  constructor(name: string, namespace: string) {
-    super(name, namespace, 'pods');
+  constructor(podConfig) {
+    super({...podConfig, kind: 'pods'});
   }
 
   async action(action: string) {

--- a/frontend/integration-tests/tests/kubevirt/models/template.ts
+++ b/frontend/integration-tests/tests/kubevirt/models/template.ts
@@ -11,8 +11,8 @@ import { KubevirtDetailView } from './kubevirtDetailView';
 
 
 export class Template extends KubevirtDetailView {
-  constructor(name: string, namespace: string) {
-    super(name, namespace, 'templates');
+  constructor(templateConfig) {
+    super({...templateConfig, kind: 'templates'});
   }
 
   async create({

--- a/frontend/integration-tests/tests/kubevirt/models/virtualMachine.ts
+++ b/frontend/integration-tests/tests/kubevirt/models/virtualMachine.ts
@@ -15,13 +15,14 @@ import { rowForName } from '../../../views/kubevirt/kubevirtDetailView.view';
 
 
 export class VirtualMachine extends KubevirtDetailView {
-  constructor(name: string, namespace: string) {
-    super(name, namespace, 'virtualmachines');
+  constructor(vmConfig) {
+    super({...vmConfig, kind: 'virtualmachines'});
   }
 
   async navigateToVmi(vmiTab: string): Promise<VirtualMachineInstance> {
     await this.navigateToTab(TABS.OVERVIEW);
-    const vmi = new VirtualMachineInstance(await vmView.vmDetailPod(this.namespace, this.name).$('a').getText(), testName);
+    const vmPodName = await vmView.vmDetailPod(this.namespace, this.name).$('a').getText();
+    const vmi = new VirtualMachineInstance({name: vmPodName, namespace: testName});
     await vmi.navigateToTab(vmiTab);
     return vmi;
   }

--- a/frontend/integration-tests/tests/kubevirt/models/virtualMachineInstance.ts
+++ b/frontend/integration-tests/tests/kubevirt/models/virtualMachineInstance.ts
@@ -2,8 +2,8 @@ import { volumeRows } from '../../../views/kubevirt/virtualMachineInstance.view'
 import { DetailView } from './detailView';
 
 export class VirtualMachineInstance extends DetailView {
-  constructor(name: string, namespace: string) {
-    super(name, namespace, 'pods');
+  constructor(vmiConfig) {
+    super({...vmiConfig, kind: 'pods'});
   }
 
   async getVolumes() {

--- a/frontend/integration-tests/tests/kubevirt/node.maintenance.scenario.ts
+++ b/frontend/integration-tests/tests/kubevirt/node.maintenance.scenario.ts
@@ -15,13 +15,12 @@ import * as podView from '../../views/kubevirt/pod.view';
 
 describe('Test Node Maintenance Mode', () => {
   const leakedResources = new Set<string>();
-  const podName = `maintenance-${testName}`;
-  const pod = new Pod(podName, testName);
+  const podResourceOpts = {name: `maintenance-${testName}`, namespace: testName, nodeSelector: {}};
+  const podResource = examplePod(podResourceOpts);
+  const pod = new Pod(podResourceOpts);
   let computeNodeName = '';
   let computeNodeHostname = '';
   let computeNodeURL = '';
-  const podResourceOpts = {name: podName, namespace: testName, nodeSelector: {}};
-  const podResource = examplePod(podResourceOpts);
 
   beforeAll(async() => {
     // Create an example hello-world pod
@@ -50,7 +49,7 @@ describe('Test Node Maintenance Mode', () => {
   afterEach(async() => {
     await browser.get(computeNodeURL);
     await isLoaded;
-    await detailViewAction('Stop Maintenance', false);
+    await detailViewAction('Stop Maintenance', true);
 
     await browser.get(`${appHost}/k8s/cluster/nodes`);
     await isLoaded();
@@ -65,7 +64,7 @@ describe('Test Node Maintenance Mode', () => {
     await browser.get(`${appHost}/k8s/ns/${testName}/pods`);
     await isLoaded();
 
-    await filterForName(podName);
+    await filterForName(pod.name);
     await browser.wait(until.and(waitForCount(resourceRows, 0)), POD_TERMINATION_TIMEOUT);
     removeLeakableResource(leakedResources, podResource);
   }, POD_CREATE_DELETE_TIMEOUT);

--- a/frontend/integration-tests/tests/kubevirt/template.actions.scenario.ts
+++ b/frontend/integration-tests/tests/kubevirt/template.actions.scenario.ts
@@ -27,6 +27,7 @@ describe('Test adding discs/nics to template', () => {
   };
 
   const templateConfig = {
+    ...commonConfig,
     name: `template-${testName}`,
     provisionSource: {
       method: 'Container',
@@ -34,16 +35,15 @@ describe('Test adding discs/nics to template', () => {
     },
     operatingSystem: basicVmConfig.operatingSystem,
     workloadProfile: basicVmConfig.workloadProfile,
-    ...commonConfig,
   };
   const vmConfig = {
+    ...commonConfig,
     name: `vm-${testName}`,
     template: templateConfig.name,
     startOnCreation: false,
-    ...commonConfig,
   };
-  const template = new Template(templateConfig.name, templateConfig.namespace);
-  const vm = new VirtualMachine(vmConfig.name, vmConfig.namespace);
+  const template = new Template(templateConfig);
+  const vm = new VirtualMachine(vmConfig);
   const wizard = new Wizard();
 
   beforeAll(async() => {

--- a/frontend/integration-tests/tests/kubevirt/template.wizard.scenario.ts
+++ b/frontend/integration-tests/tests/kubevirt/template.wizard.scenario.ts
@@ -1,51 +1,53 @@
 /* eslint-disable no-undef, max-nested-callbacks */
 import { OrderedMap } from 'immutable';
+import * as _ from 'lodash';
 
 // eslint-disable-next-line no-unused-vars
-import { networkResource, provisionOption, addLeakableResource, deleteResource, removeLeakableResource, removeLeakedResources, storageResource, createResource } from './utils/utils';
+import { networkResource, provisionOption, addLeakableResource, deleteResource, removeLeakableResource, removeLeakedResources, storageResource, createResource, getResourceObject } from './utils/utils';
 import { VM_BOOTUP_TIMEOUT } from './utils/consts';
 import { testName } from '../../protractor.conf';
-import { basicVmConfig, glusterfsDisk, networkInterface, testNad, rootDisk } from './mocks';
+import { basicVmConfig, networkInterface, testNad, rootDisk } from './mocks';
 import { VirtualMachine } from './models/virtualMachine';
 import { Template } from './models/template';
 
+const commonSettings = {
+  startOnCreation: true,
+  cloudInit: {
+    useCloudInit: false,
+  },
+  namespace: testName,
+  description: `Default description ${testName}`,
+  flavor: basicVmConfig.flavor,
+  operatingSystem: basicVmConfig.operatingSystem,
+  workloadProfile: basicVmConfig.workloadProfile,
+};
+const provisionConfigs = OrderedMap<string, {provision: provisionOption, networkResources: networkResource[], storageResources: storageResource[]}>()
+  .set('URL', {
+    provision: {
+      method: 'URL',
+      source: basicVmConfig.sourceURL,
+    },
+    networkResources: [networkInterface],
+    storageResources: [rootDisk],
+  })
+  .set('Container', {
+    provision: {
+      method: 'Container',
+      source: basicVmConfig.sourceContainer,
+    },
+    networkResources: [networkInterface],
+    storageResources: [],
+  })
+  .set('PXE', {
+    provision: {
+      method: 'PXE',
+    },
+    networkResources: [networkInterface],
+    storageResources: [rootDisk],
+  });
+
 describe('Kubevirt create VM template using wizard', () => {
   const leakedResources = new Set<string>();
-  const commonSettings = {
-    startOnCreation: true,
-    cloudInit: {
-      useCloudInit: false,
-    },
-    namespace: testName,
-    description: `Default description ${testName}`,
-    flavor: basicVmConfig.flavor,
-    operatingSystem: basicVmConfig.operatingSystem,
-    workloadProfile: basicVmConfig.workloadProfile,
-  };
-  const provisionConfigs = OrderedMap<string, {provision: provisionOption, networkResources: networkResource[], storageResources: storageResource[]}>()
-    .set('URL (+2 disks, +1 NIC)', {
-      provision: {
-        method: 'URL',
-        source: basicVmConfig.sourceURL,
-      },
-      networkResources: [networkInterface],
-      storageResources: [rootDisk, glusterfsDisk],
-    })
-    .set('Container (+2 disks, +1 NIC)', {
-      provision: {
-        method: 'Container',
-        source: basicVmConfig.sourceContainer,
-      },
-      networkResources: [networkInterface],
-      storageResources: [glusterfsDisk],
-    })
-    .set('PXE (+2 disks, +1 NIC)', {
-      provision: {
-        method: 'PXE',
-      },
-      networkResources: [networkInterface],
-      storageResources: [rootDisk, glusterfsDisk],
-    });
 
   beforeAll(async() => {
     createResource(testNad);
@@ -60,29 +62,28 @@ describe('Kubevirt create VM template using wizard', () => {
   });
 
   provisionConfigs.forEach((provisionConfig, configName) => {
-    it(`Create VM template using ${configName}.`, async() => {
-      const templateConfig = {
-        name: `tmpl-${provisionConfig.provision.method.toLowerCase()}-${testName}`,
-        provisionSource: provisionConfig.provision,
-        storageResources: provisionConfig.storageResources,
-        networkResources: provisionConfig.networkResources,
-        ...commonSettings,
-      };
-      const template = new Template(templateConfig.name, templateConfig.namespace);
+    const templateConfig = {
+      ...commonSettings,
+      name: `tmpl-${provisionConfig.provision.method.toLowerCase()}-${testName}`,
+      provisionSource: provisionConfig.provision,
+      storageResources: provisionConfig.storageResources,
+      networkResources: provisionConfig.networkResources,
+    };
+    const vmConfig = {
+      ...commonSettings,
+      name: `vm-${provisionConfig.provision.method.toLowerCase()}-${testName}`,
+      template: templateConfig.name,
+      storageResources: [],
+      networkResources: [],
+    };
+    const template = new Template(templateConfig);
+    const vm = new VirtualMachine(vmConfig);
 
+    it(`Create VM template using ${configName}.`, async() => {
       addLeakableResource(leakedResources, template.asResource());
       await template.create(templateConfig);
 
       // Verify the template can be used to create VM
-      const vmConfig = {
-        name: `vm-${provisionConfig.provision.method.toLowerCase()}-${testName}`,
-        template: templateConfig.name,
-        storageResources: [],
-        networkResources: [],
-        ...commonSettings,
-      };
-      const vm = new VirtualMachine(vmConfig.name, vmConfig.namespace);
-
       addLeakableResource(leakedResources, vm.asResource());
       await vm.create(vmConfig);
 
@@ -93,7 +94,48 @@ describe('Kubevirt create VM template using wizard', () => {
       // Remove template
       deleteResource(template.asResource());
       removeLeakableResource(leakedResources, template.asResource());
-
     }, VM_BOOTUP_TIMEOUT * 2);
+  });
+});
+
+describe('Test template datavolume cloning', () => {
+  const leakedResources = new Set<string>();
+  const provisionConfig = provisionConfigs.get('URL');
+  const templateConfig = {
+    ...commonSettings,
+    name: `tmpl-${provisionConfig.provision.method.toLowerCase()}-${testName}`,
+    provisionSource: provisionConfig.provision,
+    storageResources: provisionConfig.storageResources,
+    networkResources: [],
+  };
+  const vmConfig = {
+    ...commonSettings,
+    name: `vm-${provisionConfig.provision.method.toLowerCase()}-${testName}`,
+    template: templateConfig.name,
+    storageResources: [],
+    networkResources: [],
+  };
+  const template = new Template(templateConfig);
+  const vm = new VirtualMachine(vmConfig);
+
+  beforeAll(async() => {
+    await template.create(templateConfig);
+    addLeakableResource(leakedResources, template.asResource());
+    await vm.create(vmConfig);
+    addLeakableResource(leakedResources, vm.asResource());
+  }, VM_BOOTUP_TIMEOUT);
+
+  afterAll(() => {
+    deleteResource(vm.asResource());
+    removeLeakableResource(leakedResources, vm.asResource());
+    deleteResource(template.asResource());
+    removeLeakableResource(leakedResources, template.asResource());
+  });
+
+  it('Datavolume is cloned for VM created from template', async() => {
+    const dataVolumeName = `${vm.name}-${template.name}-${rootDisk.name}-clone`;
+    const dataVolumeObject = getResourceObject(dataVolumeName, vm.namespace, 'datavolume');
+    const srcPvc = _.get(dataVolumeObject, 'spec.source.pvc.name', undefined);
+    expect(srcPvc).toEqual(`${template.name}-${rootDisk.name}`);
   });
 });

--- a/frontend/integration-tests/tests/kubevirt/utils/utils.ts
+++ b/frontend/integration-tests/tests/kubevirt/utils/utils.ts
@@ -178,13 +178,14 @@ export function execCommandFromCli(command: string) {
     execSync(command);
   } catch (error) {
     console.error(`Failed to run ${command}:\n${error}`);
+    throw Error(`Failed to run ${command}:\n${error}`);
   }
 }
 
 export function exposeService(exposeServices: Set<any>) {
   const srvArray: Array<any> = [...exposeServices];
-  srvArray.forEach(({name, kind, port, targetPort, exposeName, type}) => {
-    execCommandFromCli(`virtctl expose ${kind} ${name} --port=${port} --target-port=${targetPort} --name=${exposeName} --type=${type}`);
+  srvArray.forEach(({name, kind, port, targetPort, exposeName, type, namespace}) => {
+    execCommandFromCli(`virtctl expose ${kind} ${name} --port=${port} --target-port=${targetPort} --name=${exposeName} --type=${type} -n ${namespace}`);
   });
 }
 

--- a/frontend/integration-tests/tests/kubevirt/vm.actions.scenario.ts
+++ b/frontend/integration-tests/tests/kubevirt/vm.actions.scenario.ts
@@ -70,7 +70,7 @@ describe('Test VM actions', () => {
 
   describe('Test VM detail view kebab actions', () => {
     const vmName = `vm-detail-view-actions-${testName}`;
-    const vm = new VirtualMachine(vmName, testName);
+    const vm = new VirtualMachine({name: vmName, namespace: testName});
 
     beforeAll(async() => {
       testVm.metadata.name = vmName;
@@ -104,7 +104,7 @@ describe('Test VM actions', () => {
 
 describe('Test VM Migration', () => {
   const testVm = getVmManifest('Container', testName);
-  const vm = new VirtualMachine(testVm.metadata.name, testVm.metadata.namespace);
+  const vm = new VirtualMachine(testVm.metadata);
 
   const MIGRATE_VM = 'Migrate Virtual Machine';
   const CANCEL_MIGRATION = 'Cancel Virtual Machine Migration';
@@ -164,12 +164,10 @@ describe('Test VM Migration', () => {
 });
 
 describe('Add/remove disks and NICs on respective VM pages', () => {
-  const testVm = getVmManifest('Container', testName);
-  const vmName = `vm-disk-nic-${testName}`;
-  const vm = new VirtualMachine(vmName, testName);
+  const testVm = getVmManifest('Container', testName, `vm-disk-nic-${testName}`);
+  const vm = new VirtualMachine(testVm.metadata);
 
   beforeAll(async() => {
-    testVm.metadata.name = vmName;
     createResources([testNad, testVm]);
     await vm.action('Start');
   });

--- a/frontend/integration-tests/tests/kubevirt/vm.nic.binding.scenario.ts
+++ b/frontend/integration-tests/tests/kubevirt/vm.nic.binding.scenario.ts
@@ -14,7 +14,7 @@ import * as kubevirtDetailView from '../../views/kubevirt/kubevirtDetailView.vie
 describe('Test VM network interface binding method', () => {
   const wizard = new Wizard();
   const vmName = `vm-${testName}`;
-  const vm = new VirtualMachine(vmName, testName);
+  const vm = new VirtualMachine({name: vmName, namespace: testName});
   const allBindingMethods = [networkBindingMethod.bridge, networkBindingMethod.masquerade, networkBindingMethod.sriov];
   const nonPodNetworkBindingMethods = [networkBindingMethod.bridge, networkBindingMethod.sriov];
 

--- a/frontend/integration-tests/tests/kubevirt/vm.wizard.scenario.ts
+++ b/frontend/integration-tests/tests/kubevirt/vm.wizard.scenario.ts
@@ -5,7 +5,7 @@ import { OrderedMap } from 'immutable';
 import { networkResource, provisionOption, deleteResource, removeLeakedResources, storageResource, addLeakableResource, createResource, removeLeakableResource } from './utils/utils';
 import { VM_BOOTUP_TIMEOUT } from './utils/consts';
 import { testName } from '../../protractor.conf';
-import { basicVmConfig, rootDisk, glusterfsDisk, networkInterface, testNad, hddDisk } from './mocks';
+import { basicVmConfig, rootDisk, networkInterface, testNad, hddDisk } from './mocks';
 import { VirtualMachine } from './models/virtualMachine';
 
 describe('Kubevirt create VM using wizard', () => {
@@ -43,7 +43,7 @@ describe('Kubevirt create VM using wizard', () => {
         method: 'PXE',
       },
       networkResources: [networkInterface],
-      storageResources: [rootDisk, glusterfsDisk],
+      storageResources: [rootDisk],
     });
 
   beforeAll(async() => {
@@ -58,13 +58,13 @@ describe('Kubevirt create VM using wizard', () => {
   provisionConfigs.forEach((provisionConfig, configName) => {
     it(`Create VM using ${configName}.`, async() => {
       const vmConfig = {
+        ...commonSettings,
         name: `vm-${provisionConfig.provision.method.toLowerCase()}-${testName}`,
         provisionSource: provisionConfig.provision,
         storageResources: provisionConfig.storageResources,
         networkResources: provisionConfig.networkResources,
-        ...commonSettings,
       };
-      const vm = new VirtualMachine(vmConfig.name, vmConfig.namespace);
+      const vm = new VirtualMachine(vmConfig);
 
       addLeakableResource(leakedResources, vm.asResource());
       await vm.create(vmConfig);

--- a/frontend/integration-tests/tests/kubevirt/vm.yaml.scenario.ts
+++ b/frontend/integration-tests/tests/kubevirt/vm.yaml.scenario.ts
@@ -9,7 +9,7 @@ import { removeLeakedResources } from './utils/utils';
 import Yaml from './models/yaml';
 import { VirtualMachine } from './models/virtualMachine';
 import { testNad, customVMWithNicDisk } from './mocks';
-import { TABS } from './utils/consts';
+import { TABS, VM_BOOTUP_TIMEOUT } from './utils/consts';
 
 describe('Test create vm from yaml', () => {
   const leakedResources = new Set<string>();
@@ -34,7 +34,7 @@ describe('Test create vm from yaml', () => {
     it('Creates VM', async() => {
       await yaml.createVMFromYaml();
       await isLoaded();
-      const vm = new VirtualMachine('example', testName);
+      const vm = new VirtualMachine({name: 'example', namespace: testName});
       await vm.action('Start');
 
       // prepare VM source for removing
@@ -56,17 +56,17 @@ describe('Test create vm from yaml', () => {
       await yamlView.setContent(customVMWithNicDisk);
       await yaml.createVMFromYaml();
       await isLoaded();
-      const vm = new VirtualMachine(`vm-${testName}`, testName);
+      const vm = new VirtualMachine({name: `vm-${testName}`, namespace: testName});
       await vm.action('Start');
 
       // Verify additional nic and disk exists.
-      // Note: 'testdisk' and 'nic1' are hard coding in vm yaml customVMWithNicDisk
+      // Note: 'testdisk' and 'nic1' are hard coded in vm yaml customVMWithNicDisk
       expect((await vm.getAttachedResources(TABS.DISKS)).includes('testdisk')).toBe(true);
       expect((await vm.getAttachedResources(TABS.NICS)).includes('nic1')).toBe(true);
 
       // prepare VM source for removing
       leakedResources.add(JSON.stringify({name: `vm-${testName}`, namespace: testName, kind: 'vm'}));
-    });
+    }, VM_BOOTUP_TIMEOUT);
   });
 
   describe('Test create VM from an invalid yaml', () => {


### PR DESCRIPTION
__Added__ https://polarion.engineering.redhat.com/polarion/redirect/project/CNV/workitem?id=CNV-1839

I'm quite curious to see your reviews on this one. I had a dilemma whether to have the test case independent for the cost of longer code and longer execution time or take advantage or an already created VM from the existing test. I decided to go for the independent TC.

Maybe a bit simpler and definitely faster way of doing this would be storing the datavolume object at the time we have created a VM from URL source and verify the pvc source later, but the datavolume test would then depend on the previous ones.

