### PR TITLE
[WIPTEST] fixed sidenav.view.ts navigation issue

### DIFF
--- a/frontend/integration-tests/views/sidenav.view.ts
+++ b/frontend/integration-tests/views/sidenav.view.ts
@@ -2,11 +2,15 @@
 
 import { $$, by, browser, element, ExpectedConditions as until } from 'protractor';
 
-export const navSectionFor = (name: string) => element(by.cssContainingText('.pf-c-nav > .pf-c-nav__list > .pf-c-nav__item', name));
+export const navSectionFor = (name: string) => element(by.linkText(name));
 
 export const clickNavLink = (path: [string, string]) => browser.wait(until.visibilityOf(navSectionFor(path[0])))
-  .then(() => navSectionFor(path[0]).click())
-  .then(() => browser.wait(until.visibilityOf(navSectionFor(path[0]).element(by.linkText(path[1])))))
-  .then(() => navSectionFor(path[0]).element(by.linkText(path[1])).click());
+  .then(() => navSectionFor(path[0]).getAttribute('aria-expanded').then(function(value) {
+    if (value === 'false') {
+      navSectionFor(path[0]).click();
+    }
+  }))
+  .then(() => browser.wait(until.visibilityOf(navSectionFor(path[1]))))
+  .then(() => navSectionFor(path[1]).click());
 
 export const activeLink = $$('.pf-c-nav__link.pf-m-current');


### PR DESCRIPTION
The sidenav.view.ts in it current state is not working. i tested it with existing tests and got failures.
After proposed fix, these tests passed.

Also I introduced handling to expanded/collapsed menu item, meaning if a menu is already opened, it should not be clicked 