### PR TITLE
Pass vCenter secrets to create VM wizard

### DIFF
--- a/frontend/public/kubevirt/components/modals/create-vm-modal.js
+++ b/frontend/public/kubevirt/components/modals/create-vm-modal.js
@@ -13,6 +13,7 @@ import {
 } from '../../models';
 import { WithResources } from '../utils/withResources';
 import { units } from '../utils/okdutils';
+import { SecretModel } from '../../../models';
 
 export const openCreateVmWizard = ( activeNamespace, createTemplate = false ) => {
   const launcher = modalResourceLauncher(CreateVmWizard, {
@@ -40,6 +41,9 @@ export const openCreateVmWizard = ( activeNamespace, createTemplate = false ) =>
     },
     dataVolumes: {
       resource:  getResource(DataVolumeModel, {namespace: activeNamespace}),
+    },
+    vCenterSecrets: {
+      resource: getResource(SecretModel, {namespace: activeNamespace}),
     },
   },(({namespaces, userTemplates, commonTemplates}) => {
       let selectedNamespace;


### PR DESCRIPTION
vCenter secrets need to be passed to the create VM wizard to enable saving vCenter credentials.

Bug: https://bugzilla.redhat.com/1714004